### PR TITLE
Fix box-sizing in Firefox

### DIFF
--- a/stylesheets/base/_base.scss
+++ b/stylesheets/base/_base.scss
@@ -1,6 +1,7 @@
 *,
 *:before,
 *:after {
+  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Firefox has good support for `box-sizing` but doesn't without the `-moz-` prefix. Though it is planning to introduce the un-prefixed version in Firefox 29 (we're on 28 at the moment) but this should sort it for older versions which people haven't updated.

More info: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
