### PR TITLE
Remove dependency on google font loader class

### DIFF
--- a/stylesheets/lib/_typography.scss
+++ b/stylesheets/lib/_typography.scss
@@ -79,27 +79,19 @@
 }
 
 %font-body {
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'museo_sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 300;
-  .wf-museosans-n4-active & {
-    font-family: 'museo_sans';
-  }
 }
 
 %font-heading-medium {
-  font-family: Arial;
+  font-family: 'museo_sans', Arial, sans-serif;
   font-weight: 500;
-  .wf-museosans-n4-active & {
-    font-family: 'museo_sans';
-  }
 }
 
+
 %font-heading-heavy {
-  font-family: Arial;
+  font-family: 'museo_sans', Arial, sans-serif;
   font-weight: 700;
-  .wf-museosans-n4-active & {
-    font-family: 'museo_sans';
-  }
 }
 
 %heading-extra-large {


### PR DESCRIPTION
Previously we were using a google font loader class (wf-museosans-n4-active) to display our custom font. This is not needed anymore - and was meaning that engines weren't displaying the custom font - so I've removed it from our css.
