### PR TITLE
Compact button - stop border from flipping to top of button when pressed

### DIFF
--- a/stylesheets/components/common/_button.scss
+++ b/stylesheets/components/common/_button.scss
@@ -90,6 +90,11 @@
   height: 52px;
   width: 93px;
 
+  &:active {
+    border-top: 0;
+    padding-top: 8px;
+  }
+
   > .icon {
     position: relative;
     top:5px;


### PR DESCRIPTION
This stops the button from changing height when pressed and forcing its container height to change eg when placed on the fixed footer
