### PR TITLE
Return base font size to 16px to prevent max-width screwing up

### DIFF
--- a/stylesheets/lib/_typography.scss
+++ b/stylesheets/lib/_typography.scss
@@ -142,10 +142,6 @@
 %type {
   @extend %font-body;
   @include body(16, 22);
-
-  @include respond-to($mq-l) {
-    @include body(18, 24);
-  }
 }
 
 %type-small {


### PR DESCRIPTION
@aduggin
