### PR TITLE
Promote the add-action component from /frontend to dough

### DIFF
--- a/stylesheets/components/common/_add-action.scss
+++ b/stylesheets/components/common/_add-action.scss
@@ -1,0 +1,40 @@
+// CTA callout panel
+//
+// .add-action - Default
+// .add-action--padded - Adds additional padding around content
+//
+// Styleguide Add Action CTA panel
+
+.add-action {
+  position: relative;
+  background-color: $color-cta-callout;
+  padding: $baseline-unit $baseline-unit*2;
+  display: block;
+  margin: $baseline-unit*5 0;
+  clear: both;
+
+  &:before {
+    position: absolute;
+    top: -10px;
+    left: 0;
+    content: '';
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 10px 0 0 10px;
+    border-color: transparent transparent transparent $color-cta-callout;
+  }
+
+  a {
+    border-bottom: 0;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+}
+
+.add-action--padded {
+  padding: $baseline-unit*3;
+}

--- a/stylesheets/lib/_variables.scss
+++ b/stylesheets/lib/_variables.scss
@@ -132,3 +132,6 @@ $color-search-text: $color-grey-medium-dark !default;
 $color-validation-border: $color-red-light !default;
 $color-validation-text: $color-red-medium !default;
 $color-validation-summary-background: $color-pink-light !default;
+
+// CTA callout
+$color-cta-callout: $color-blue-light !default;


### PR DESCRIPTION
We are now using this on Action Plans so I have promoted it from frontend to a common component of dough.

An `.add-action--padded` modifier was also added.
