### PR TITLE
[WIP] Add a function to convert px to rem

### DIFF
--- a/stylesheets/lib/_grid.scss
+++ b/stylesheets/lib/_grid.scss
@@ -1,7 +1,17 @@
+
+// Utility function for converting px to rem if the responsive flag is set. To be used instead of the $baseline-unit variable.
+@function px($px) {
+  @if $responsive == true {
+    @return ($px / 16) + rem
+  }
+  @return $px + px
+}
+
 // Defaults which you can freely override
 $column-width: 60px !default;
 $gutter-width: 40px !default;
 $columns: 12 !default;
+
 
 @function px-to-em($px) {
   @return ($px / 16) * 1em;


### PR DESCRIPTION
Having used $baseline-unit for a while I have found that restricting ourselves to 6px increments actually break the baseline grid. Where, for example, an element has a border and the padding is set using the variable it will always sit off the vertical baseline grid.

This will need a refactor of the code base.
