### PR TITLE
Remove visited state on buttons and adjust active state

### DIFF
--- a/stylesheets/components/common/_button.scss
+++ b/stylesheets/components/common/_button.scss
@@ -29,6 +29,10 @@
   cursor: pointer;
   filter: none;
 
+  &:visited {
+    color: $color-button-default-text;
+  }
+
   &:focus {
     outline: thin dotted;
     outline: 3px auto -webkit-focus-ring-color;


### PR DESCRIPTION
@moneyadviceservice/frontend

Adjust style for active state (as per AGC comments).

Should a button (rather than a link) have an active state, AGC, Jon and I think not but would be interested to hear opposing views.
