### PR TITLE
Left align text in tbody th in IE8-11

### DIFF
--- a/stylesheets/components/common/_tables.scss
+++ b/stylesheets/components/common/_tables.scss
@@ -40,6 +40,10 @@ thead > tr {
   background-color: $color-table-background;
 }
 
+tbody th {
+  text-align: left;
+}
+
 th, td {
   vertical-align: top;
   padding: $baseline-unit*2;


### PR DESCRIPTION
Fixes issue where text appears centre-aligned when using a <th> within a <tbody>
