### PR TITLE
Bold the label on errored state

### DIFF
--- a/stylesheets/components/common/_form.scss
+++ b/stylesheets/components/common/_form.scss
@@ -42,6 +42,7 @@
 
   label {
     color: $color-validation-text;
+    font-weight: bold;
   }
 }
 


### PR DESCRIPTION
(as per design)

![screen shot 2014-07-01 at 13 54 20](https://cloud.githubusercontent.com/assets/1579511/3443168/e1843b04-011e-11e4-882e-30c880d49b66.png)
