### PR TITLE
Remove focus ring from focussed tab

### DIFF
--- a/assets/js/components/TabSelector.js
+++ b/assets/js/components/TabSelector.js
@@ -240,7 +240,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
         .addClass(this.selectors.activeClass)
         .attr({
           'aria-hidden': 'false',
-          'tabindex': 0
+          'tabindex': -1
         });
 
     this._focusTarget($selectedTarget);
@@ -249,9 +249,9 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
         .removeClass(this.selectors.activeClass)
         .addClass(this.selectors.inactiveClass)
         .attr({
-          'aria-hidden': 'true',
-          'tabindex': -1
-        });
+          'aria-hidden': 'true'
+        })
+        .removeAttr('tabindex');
 
     return this;
   };


### PR DESCRIPTION
Removed blue outline on focussed tab:
https://www.moneyadviceservice.org.uk/en/tools/pension-calculator/stewd?utf8=%E2%9C%93&display_frequency=yearly&dob_day=4&dob_month=9&dob_year=1968&gender=male&pot_1=0&pot_2=0&pot_3=0&pot_employee_contribution_currency=0&pot_employee_contribution_currency_frequency=yearly&pot_employee_contribution_datatype=currency&pot_employee_contribution_percentage=0&pot_employer_contribution_currency=0&pot_employer_contribution_currency_frequency=yearly&pot_employer_contribution_datatype=currency&pot_employer_contribution_percentage=0&salary=9288&salary_frequency=yearly&salary_range_salary=1545&salary_range_salary_frequency=monthly
