### PR TITLE
Change base paragraph size to be 16px and 18px in .editorial content

### DIFF
--- a/assets/stylesheets/base/_base.scss
+++ b/assets/stylesheets/base/_base.scss
@@ -40,10 +40,8 @@ h4 {
 //
 // Styleguide p
 
-p {
-  .editorial & {
-    @extend %paragraph;
-  }
+.editorial p {
+  @extend %paragraph;
 }
 
 b,


### PR DESCRIPTION
@moneyadviceservice/frontend 

Matt has decided to go with a base paragraph size of 16px (not 18px) unless the content is editorial (lives inside the .editorial namespace.

Pretty sure this may cause issues, so let me know :rotating_light: 
