### PR TITLE
Only add the rspec task when in development and test mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Bundler::GemHelper.install_tasks
 
 require 'dough'
 
-if ENV['RAILS_ENV'] == 'test' or ENV['RAILS_ENV'] == 'development'
+if Rails.env.test? or Rails.env.development?
   require 'rspec/core'
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec) do |spec|


### PR DESCRIPTION
Add to stop our Go build from trying to require the spec_helper file.
