### PR TITLE
Merge uiEvents into defaultConfig

### DIFF
--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -27,7 +27,7 @@ define([], function() {
      */
     this.attrs = [];
 
-    this._bindUiEvents(this.uiEvents || {});
+    this._bindUiEvents(this.config.uiEvents || {});
     return this;
   }
 

--- a/assets/js/components/TabSelector.js
+++ b/assets/js/components/TabSelector.js
@@ -17,7 +17,10 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
 
       var TabSelector,
           defaultConfig = {
-            collapseInSmallViewport: false
+            collapseInSmallViewport: false,
+            uiEvents: {
+              'click [data-dough-tab-selector-trigger]': '_handleClickEvent'
+            }
           },
           selectors = {
             triggersOuter: '[data-dough-tab-selector-triggers-outer]',
@@ -27,9 +30,6 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
             target: 'data-dough-tab-selector-target',
             activeClass: 'is-active',
             inactiveClass: 'is-inactive'
-          },
-          uiEvents = {
-            'click [data-dough-tab-selector-trigger]': '_handleClickEvent'
           },
           i18nStrings = {
             selected: 'selected',
@@ -43,7 +43,6 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
       TabSelector = function($el, config) {
         var triggerId;
 
-        this.uiEvents = uiEvents;
         TabSelector.baseConstructor.call(this, $el, config, defaultConfig);
         this.i18nStrings = (config && config.i18nStrings) ? config.i18nStrings : i18nStrings;
         this.selectors = $.extend(this.selectors || {}, selectors);

--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -22,22 +22,20 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     validationSummaryListAttribute: 'data-dough-validation-summary-list',
     validationSummaryHiddenClass: 'validation-summary--hidden',
     validationSummaryErrorClass: 'validation-summary__error',
-    inlineErrorClass: 'js-inline-error'
-  },
-
-  uiEvents = {
-    'blur input, select, textarea': '_handleBlurEvent',
-    'keyup input, textarea': '_handleChangeEvent',
-    'change input, select': '_handleChangeEvent',
-    'submit': '_handleSubmit'
-  },
+    inlineErrorClass: 'js-inline-error',
+    uiEvents: {
+      'blur input, select, textarea': '_handleBlurEvent',
+      'keyup input, textarea': '_handleChangeEvent',
+      'change input, select': '_handleChangeEvent',
+      'submit': '_handleSubmit'
+    }
+  };
 
   /**
    * Call base constructor
    * @constructor
    */
   Validation = function($el, config) {
-    this.uiEvents = uiEvents;
     Validation.baseConstructor.call(this, $el, config, defaultConfig);
   };
 


### PR DESCRIPTION
As per discussions with @jonnywyatt , we think that `uiEvents` should be part of `defaultConfig`.
Anything specified within `defaultConfig` is automatically added to `this.config` so it will help reduce boilerplate such as `this.uiEvents = uiEvents` within each component’s constructor.

Note: Can be merged as is. Another PR will bring other configs (i18nStrings, selectors, etc) into `defaultConfig` helping to eliminate further boilerplate code such as `this.selectors = selectors`
