### PR TITLE
Work around chrome caret bug.

### DIFF
--- a/assets/stylesheets/helpers/_form-input.scss
+++ b/assets/stylesheets/helpers/_form-input.scss
@@ -12,5 +12,4 @@
 
 %form-input-text {
   height: $baseline-unit*5;
-  line-height: $baseline-unit*5;
 }


### PR DESCRIPTION
Fixes #175.

I've tested on all the IEs, Firefoxes and Chromes five versions back, Safari 5.1/6/7, iOS 4/5.1/6/7/8, Android 1.6/2.3/4.1/4.4, Opera mobile.

The only issue I saw was on Android 1.6, in which when the input box was selected the font was slightly bigger than the text field. That happened regardless of this change, however.

There are very slight visual changes in Chrome. The input text has a slightly lower position in the text box, by maybe one pixel.
