### PR TITLE
inset_block supports ActiveSupport::SafeBuffer

### DIFF
--- a/lib/dough/helpers.rb
+++ b/lib/dough/helpers.rb
@@ -48,7 +48,7 @@ module Dough
 
     def merge_optional_string(args)
       new_args = {}
-      args.push text: args.slice!(0) if args.first.class == String
+      args.push text: args.slice!(0) if args.first.kind_of?(String)
       args.each { |arg| new_args.merge!(arg) }
 
       new_args

--- a/spec/lib/dough/helpers/renderer_spec.rb
+++ b/spec/lib/dough/helpers/renderer_spec.rb
@@ -35,6 +35,22 @@ module Dough
             end
           end
 
+          context 'when ActiveSupport::SafeBuffer' do
+            controller do
+              helper Dough::Helpers
+
+              def index
+                render(inline: "<%= inset_block ActiveSupport::SafeBuffer.new('Some instructional text') %>")
+              end
+            end
+
+            it 'renders the template' do
+              get :index
+
+              expect(response.body).to include('Some instructional text')
+            end
+          end
+
           context 'helper template not found' do
             controller do
               helper Dough::Helpers


### PR DESCRIPTION
Using rails translation helpers will return ActiveSupport::SafeBuffer
This change makes those helpers compatible
