### PR TITLE
Allow deferred components

### DIFF
--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -31,6 +31,7 @@ define(['jquery', 'rsvp'], function($, RSVP) {
     /**
      * Create components based on the supplied DOM fragment (or document if not supplied)
      * @param {jQuery} [$container]
+     * @param {boolean} [includeDeferred] - Includes deferred objects when initialising components
      * @returns {object} - a promise that will resolve or reject depending on whether all modules
      * initialise successfully
      */
@@ -74,6 +75,7 @@ define(['jquery', 'rsvp'], function($, RSVP) {
     /**
      * Make an array of objects, each containing pointers to a component container and name
      * @param {object} $container
+     * @param {boolean} [includeDeferred] - Includes deferred objects when initialising components
      * @returns {Array}
      * @private
      */
@@ -82,9 +84,13 @@ define(['jquery', 'rsvp'], function($, RSVP) {
           $els,
           $el,
           attrs,
-          deferredSelector = !includeDeferred? ':not([data-dough-defer])' : '';
+          selector = '[data-dough-component]';
 
-      $els = $container.find('[data-dough-component]' + deferredSelector);
+      if (!includeDeferred) {
+        selector += ':not([data-dough-defer])';
+      }
+
+      $els = $container.is(selector)? $container : $container.find(selector);
       $els.each(function() {
         $el = $(this);
         attrs = $el.attr('data-dough-component').split(' ');

--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -34,7 +34,7 @@ define(['jquery', 'rsvp'], function($, RSVP) {
      * @returns {object} - a promise that will resolve or reject depending on whether all modules
      * initialise successfully
      */
-    init: function($container) {
+    init: function($container, includeDeferred) {
       var componentsToCreate,
           instantiatedList,
           initialisedList,
@@ -44,7 +44,7 @@ define(['jquery', 'rsvp'], function($, RSVP) {
       this.components = {};
       // if no DOM fragment supplied, use the document
       $container = $container || $('body');
-      componentsToCreate = this._listComponentsToCreate($container);
+      componentsToCreate = this._listComponentsToCreate($container, includeDeferred || false);
       instantiatedList = this._createPromises(componentsToCreate);
       initialisedList = this._createPromises(componentsToCreate);
       if (componentsToCreate.length) {
@@ -77,13 +77,14 @@ define(['jquery', 'rsvp'], function($, RSVP) {
      * @returns {Array}
      * @private
      */
-    _listComponentsToCreate: function($container) {
+    _listComponentsToCreate: function($container, includeDeferred) {
       var componentsToCreate = [],
           $els,
           $el,
-          attrs;
+          attrs,
+          deferredSelector = !includeDeferred? ':not([data-dough-defer])' : '';
 
-      $els = $container.find('[data-dough-component]');
+      $els = $container.find('[data-dough-component]' + deferredSelector);
       $els.each(function() {
         $el = $(this);
         attrs = $el.attr('data-dough-component').split(' ');

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.1.0'
+  VERSION = '5.2.0'
 end

--- a/spec/js/fixtures/componentLoader.html
+++ b/spec/js/fixtures/componentLoader.html
@@ -30,4 +30,5 @@
     <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2"></div>
   </div>
   <form data-dough-component="RangeInput Collapsable"></form>
+  <div data-dough-component="RangeInput" data-dough-defer></div>
 </div>

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -36,7 +36,7 @@ describe('componentLoader', function() {
 
       // NOTE: components add a "data-dough-<componentName>-initialised='yes'" attribute to themselves once
       // they have successfully initialised
-      this.$html.find('[data-dough-component]').each(function(){
+      this.$html.find('[data-dough-component]:not([data-dough-defer])').each(function() {
         $component = $(this);
         componentNames = $component.attr('data-dough-component').split(' ');
         $.each(componentNames, function(idx, componentName) {
@@ -46,6 +46,30 @@ describe('componentLoader', function() {
         });
       });
       expect(allInitialised).to.equal(true);
+    });
+
+    it('should ignore deferred components', function() {
+      var allInitialised = true;
+
+      this.$html.find('[data-dough-component][data-dough-defer]').each(function() {
+        var $component,
+            componentName;
+
+        $component = $(this);
+        componentName = $component.attr('data-dough-component').split(' ');
+        if (!$component.is('[data-dough-' + componentName + '-initialised="yes"]')) {
+          allInitialised = false;
+        }
+      });
+    });
+
+    it('should enable a deferred component', function(done) {
+      var $deferredComponent = this.$html.find('[data-dough-component][data-dough-defer]').eq(0);
+
+      this.componentLoader.init(this.$html, true).then(function() {
+        expect($deferredComponent.is('[data-dough-' + $deferredComponent.attr('data-dough-component') + '-initialised="yes"]')).to.be.true;
+        done();
+      });
     });
 
     it('should set a flag to indicate all components have been initialised', function() {

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -61,6 +61,7 @@ describe('componentLoader', function() {
           allInitialised = false;
         }
       });
+      expect(allInitialised).to.be.false;
     });
 
     it('should enable a deferred component', function(done) {

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -42,6 +42,7 @@ describe('componentLoader', function() {
         $.each(componentNames, function(idx, componentName) {
           if (!$component.is('[data-dough-' + componentName + '-initialised="yes"]')) {
             allInitialised = false;
+            return false;
           }
         });
       });
@@ -59,6 +60,7 @@ describe('componentLoader', function() {
         componentName = $component.attr('data-dough-component').split(' ');
         if (!$component.is('[data-dough-' + componentName + '-initialised="yes"]')) {
           allInitialised = false;
+          return false;
         }
       });
       expect(allInitialised).to.be.false;


### PR DESCRIPTION
Use the `[data-dough-defer]` attribute to defer a component:

```html
<div data-dough-component="RangeInput" data-dough-defer>...</div>
```

Then to initialise deferred components, use the optional `includeDeferred` flag as 2nd param in `componentLoader.init($container, true)`