### PR TITLE
[WIP]New Sass fixes

### DIFF
--- a/assets/stylesheets/_lib.scss
+++ b/assets/stylesheets/_lib.scss
@@ -1,1 +1,2 @@
 @import 'lib/variables';
+@import 'lib/typography';

--- a/assets/stylesheets/components/common/_validation_summary.scss
+++ b/assets/stylesheets/components/common/_validation_summary.scss
@@ -5,7 +5,6 @@
 }
 
 .validation-summary__content-container {
-  @extend .is-errored;
   background: $color-validation-summary-background;
 }
 


### PR DESCRIPTION
I initially replaced it with `.form__row--is-errored` since seemed to be the natural descendent of `.is-errored`, but it didn't have any effect in this case and it wasn't semantically correct.

`.is-errored` is used a [bunch of other times](https://github.com/moneyadviceservice/dough/search?utf8=%E2%9C%93&q=is-errored) in this repo, and relied on in tests. It's probably worth investigating.

Feel free to push to this branch if you know what should be happening!

Part of https://github.com/moneyadviceservice/frontend/pull/891.