### PR TITLE
Fix missing componentName in DoughBaseComponent

### DIFF
--- a/assets/js/components/Collapsable.js
+++ b/assets/js/components/Collapsable.js
@@ -16,8 +16,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
   'use strict';
 
   // Class variables
-  var CollapsableProto,
-      defaultConfig = {
+  var defaultConfig = {
         componentName: 'Collapsable',
         hideOnBlur: false,
         forceTo: false,
@@ -63,6 +62,8 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
    * Inherit from base module, for shared methods and interface
    */
   DoughBaseComponent.extend(Collapsable);
+
+  Collapsable.componentName = 'Collapsable';
 
   /**
    * Setups accessibility functionality for trigger and target buttons

--- a/assets/js/components/Collapsable.js
+++ b/assets/js/components/Collapsable.js
@@ -16,7 +16,9 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
   'use strict';
 
   // Class variables
-  var defaultConfig = {
+  var CollapsableProto,
+      defaultConfig = {
+        componentName: 'Collapsable',
         hideOnBlur: false,
         forceTo: false,
         oneGroupOpenOnly: false,

--- a/assets/js/components/Collapsable.js
+++ b/assets/js/components/Collapsable.js
@@ -17,7 +17,6 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
 
   // Class variables
   var defaultConfig = {
-        componentName: 'Collapsable',
         hideOnBlur: false,
         forceTo: false,
         oneGroupOpenOnly: false,

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -10,7 +10,7 @@
  * @module DoughBaseComponent
  * @returns {class} DoughBaseComponent
  */
-define([], function() {
+define(['utilities'], function(utilities) {
   'use strict';
 
   var DoughBaseComponent;
@@ -150,7 +150,7 @@ define([], function() {
    * promise will be fed back to the component loader
    */
   DoughBaseComponent.prototype._initialisedSuccess = function(initialised) {
-    this.$el.attr('data-dough-' + this.componentName + '-initialised', 'yes');
+    this.$el.attr('data-dough-' + this.componentAttributeName + '-initialised', 'yes');
     initialised && initialised.resolve(this.componentName);
   };
 
@@ -168,7 +168,7 @@ define([], function() {
    * @param  {string} componentName The componentName to check
    * @private
    */
-  DoughBaseComponentProto._setComponentName = function(componentName) {
+  DoughBaseComponent.prototype._setComponentName = function(componentName) {
     var warning,
         componentDataAttr = this.$el.data('dough-component');
 

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -166,7 +166,6 @@ define(['utilities'], function(utilities) {
    * Checks whether a componentName has been passed via the config and whether it is actually
    * present in [data-dough-component] and displays a warning
    * @param  {string} componentName The componentName to check
-   * @private
    */
   DoughBaseComponent.prototype._setComponentName = function(componentName) {
     var warning,

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -167,13 +167,15 @@ define([], function() {
    * @private
    */
   DoughBaseComponentProto._setComponentName = function(componentName) {
-    var warning;
+    var warning,
+        componentDataAttr = this.$el.data('dough-component');
 
     if (typeof componentName !== 'undefined') {
-      if (this.$el.data('dough-component').indexOf(componentName)) {
-        warning = '\'' + componentName + '\' componentName was not found in the data-dough-component attribute';
+      if (componentDataAttr && componentDataAttr.indexOf(componentName) === -1) {
+        warning = '"' + componentName + '"' + ' componentName was not found in the data-dough-component attribute';
       }
       this.componentName = componentName;
+      this.componentAttributeName = utilities.convertCamelCaseToDashed(componentName);
     }
     else {
       warning = 'componentName not specified';

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -29,8 +29,10 @@ define([], function() {
       throw new Error('Element not supplied to DoughBaseComponent constructor');
     }
     this.config = $.extend({}, defaultConfig || {}, config || {});
-    this.componentName = this.config.componentName;
+
     this.setElement($el);
+
+    this._setComponentName(this.config.componentName);
     /*
      Populate this array with the data attributes this module will use.
      Exclude 'data-dough-' prefix, as this is automatically added.
@@ -156,6 +158,30 @@ define([], function() {
    */
   DoughBaseComponent.prototype._initialisedFailure = function(initialised) {
     initialised && initialised.reject(this.componentName);
+  };
+
+  /**
+   * Checks whether a componentName has been passed via the config and whether it is actually
+   * present in [data-dough-component] and displays a warning
+   * @param  {string} componentName The componentName to check
+   * @private
+   */
+  DoughBaseComponentProto._setComponentName = function(componentName) {
+    var warning;
+
+    if (typeof componentName !== 'undefined') {
+      if (this.$el.data('dough-component').indexOf(componentName)) {
+        warning = '\'' + componentName + '\' componentName was not found in the data-dough-component attribute';
+      }
+      this.componentName = componentName;
+    }
+    else {
+      warning = 'componentName not specified';
+    }
+
+    if (warning && console && console.warn) {
+      console.warn(warning);
+    }
   };
 
   return DoughBaseComponent;

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -28,11 +28,11 @@ define([], function() {
     if (!$el || !$el.length) {
       throw new Error('Element not supplied to DoughBaseComponent constructor');
     }
+
     this.config = $.extend({}, defaultConfig || {}, config || {});
-
     this.setElement($el);
-
     this._setComponentName(this.config.componentName);
+
     /*
      Populate this array with the data attributes this module will use.
      Exclude 'data-dough-' prefix, as this is automatically added.

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -31,7 +31,7 @@ define([], function() {
 
     this.config = $.extend({}, defaultConfig || {}, config || {});
     this.setElement($el);
-    this._setComponentName(this.config.componentName);
+    this._setComponentName(this.constructor.componentName);
 
     /*
      Populate this array with the data attributes this module will use.
@@ -44,6 +44,8 @@ define([], function() {
     this._bindUiEvents(this.config.uiEvents || {});
     return this;
   };
+
+  DoughBaseComponent.componentName = 'DoughBaseComponent';
 
   /**
    * Extend DoughBaseComponent class using the supplied constructor

--- a/assets/js/components/FieldHelpText.js
+++ b/assets/js/components/FieldHelpText.js
@@ -8,8 +8,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var defaultConfig = {
-    componentName: 'FieldHelpText',
-
     // Used to show/hide tooltip with focus
     hiddenClass: 'field-help-text--hidden',
 
@@ -35,6 +33,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   };
 
   DoughBaseComponent.extend(FieldHelpText);
+
+	FieldHelpText.componentName = 'FieldHelpText';
 
   /**
    * Initialises component

--- a/assets/js/components/FieldHelpText.js
+++ b/assets/js/components/FieldHelpText.js
@@ -34,7 +34,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
   DoughBaseComponent.extend(FieldHelpText);
 
-	FieldHelpText.componentName = 'FieldHelpText';
+  FieldHelpText.componentName = 'FieldHelpText';
 
   /**
    * Initialises component

--- a/assets/js/components/FieldHelpText.js
+++ b/assets/js/components/FieldHelpText.js
@@ -8,6 +8,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var defaultConfig = {
+    componentName: 'FieldHelpText',
+
     // Used to show/hide tooltip with focus
     hiddenClass: 'field-help-text--hidden',
 

--- a/assets/js/components/RangeInput.js
+++ b/assets/js/components/RangeInput.js
@@ -12,6 +12,7 @@ define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
   'use strict';
 
   var defaultConfig = {
+        componentName: 'RangeInput',
         keepSynced: true
       },
       RangeInput;

--- a/assets/js/components/RangeInput.js
+++ b/assets/js/components/RangeInput.js
@@ -12,7 +12,6 @@ define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
   'use strict';
 
   var defaultConfig = {
-        componentName: 'RangeInput',
         keepSynced: true
       },
       RangeInput;
@@ -30,6 +29,8 @@ define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
   };
 
   DoughBaseComponent.extend(RangeInput);
+
+  RangeInput.componentName = 'RangeInput';
 
   /**
    * Init - detect range type support and clone input / label

--- a/assets/js/components/TabSelector.js
+++ b/assets/js/components/TabSelector.js
@@ -12,6 +12,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
 
       var TabSelector,
           defaultConfig = {
+            componentName: 'TabSelector',
             collapseInSmallViewport: false,
             uiEvents: {
               'click [data-dough-tab-selector-trigger]': '_handleClickEvent'

--- a/assets/js/components/TabSelector.js
+++ b/assets/js/components/TabSelector.js
@@ -12,7 +12,6 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
 
       var TabSelector,
           defaultConfig = {
-            componentName: 'TabSelector',
             collapseInSmallViewport: false,
             uiEvents: {
               'click [data-dough-tab-selector-trigger]': '_handleClickEvent'
@@ -68,6 +67,8 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
        * Inherit from base module, for shared methods and interface
        */
       DoughBaseComponent.extend(TabSelector);
+
+      TabSelector.componentName = 'TabSelector';
 
       /**
        * Initialise component

--- a/assets/js/components/TabularTooltip.js
+++ b/assets/js/components/TabularTooltip.js
@@ -11,9 +11,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var TabularTooltip,
-      defaultConfig = {
-        componentName: 'TabularTooltip'
-      };
+      defaultConfig = {};
 
   /**
    * @constructor

--- a/assets/js/components/TabularTooltip.js
+++ b/assets/js/components/TabularTooltip.js
@@ -10,15 +10,19 @@
 define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
-  var TabularTooltip;
+  var TabularTooltip,
+			defaultConfig = {
+        componentName: 'TabularTooltip'
+      };
 
   /**
    * @constructor
    * @extends {DoughBaseComponent}
    * @returns {TabularTooltip}
    */
-  TabularTooltip = function() {
-    TabularTooltip.baseConstructor.apply(this, arguments);
+
+  TabularTooltip = function($el, config) {
+    TabularTooltip.baseConstructor.call(this, $el, config, defaultConfig);
   };
 
   DoughBaseComponent.extend(TabularTooltip);

--- a/assets/js/components/TabularTooltip.js
+++ b/assets/js/components/TabularTooltip.js
@@ -11,7 +11,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var TabularTooltip,
-			defaultConfig = {
+      defaultConfig = {
         componentName: 'TabularTooltip'
       };
 
@@ -26,6 +26,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   };
 
   DoughBaseComponent.extend(TabularTooltip);
+
+  TabularTooltip.componentName = 'TabularTooltip';
 
   /**
    * Initialise component

--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -13,6 +13,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var defaultConfig = {
+        componentName: 'Validation',
         fieldSelector: 'input, textarea, select',
         attributeEmpty: 'data-dough-validation-empty',
         attributeInvalid: 'data-dough-validation-invalid',

--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -13,7 +13,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
   var defaultConfig = {
-        componentName: 'Validation',
         fieldSelector: 'input, textarea, select',
         attributeEmpty: 'data-dough-validation-empty',
         attributeInvalid: 'data-dough-validation-invalid',
@@ -42,6 +41,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   };
 
   DoughBaseComponent.extend(Validation);
+
+  Validation.componentName = 'Validation';
 
   Validation.prototype.init = function(initialised) {
     this.ATTRIBUTE_VALIDATORS = {

--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -16,14 +16,14 @@
  * @module componentLoader
  * @returns {Function} componentLoader
  */
-define(['jquery', 'rsvp'], function($, RSVP) {
+define(['jquery', 'rsvp', 'utilities'], function($, RSVP, utilities) {
 
   'use strict';
 
   return {
 
     /**
-     * Stores Each key will store a component name and an array of
+     * Each key will store a component name and an array of
      * instances of that component type.
      * @attribute
      * @type {Object}
@@ -199,27 +199,14 @@ define(['jquery', 'rsvp'], function($, RSVP) {
      * @returns {object} - parsed JSON config or empty object
      */
     _parseConfig: function($el, componentName) {
-      var config = $el.attr('data-dough-' + this._convertComponentNameToDashed(componentName) + '-config');
+      var config = $el.attr('data-dough-' + utilities.convertCamelCaseToDashed(componentName) + '-config');
       try {
         config = JSON.parse(config);
       } catch (err) {
         config = {};
       }
       return config;
-    },
-
-    /**
-     * Converts camelcase component name to dashed
-     * @param {string} componentName eg. TabSelector
-     * @returns {string} eg. tab-selector
-     */
-    _convertComponentNameToDashed: function(componentName) {
-      var val = componentName.replace(/([A-Z])/g, function($1) {
-        return '-' + $1.toLowerCase();
-      });
-      return val.substr(1);
     }
-
   };
 
 });

--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -153,7 +153,6 @@ define(['jquery', 'rsvp', 'utilities'], function($, RSVP, utilities) {
 
       require([componentName], function(Constr) {
         if (!Constr.isSingleton || !self.components[componentName]) {
-          config.componentName = componentName;
           if (!self.components[componentName]) {
             self.components[componentName] = [];
           }

--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -1,3 +1,4 @@
+//= require dough/assets/js/lib/utilities
 /**
  * UI component loader. Scans the supplied DOM for 'data-dough-component' attributes and initialises
  * components based on those attribute values

--- a/assets/js/lib/utilities.js
+++ b/assets/js/lib/utilities.js
@@ -25,6 +25,19 @@ define([], function() {
     numberToCurrency: function(num) {
       var re = '\\d(?=(\\d{3})+$)';
       return '£' + Math.round(num).toFixed(0).replace(new RegExp(re, 'g'), '$&,');
+    },
+
+    /**
+     * Converts a CamelCase string to a dashed one
+     * @param {string} str eg. TabSelector
+     * @private
+     * @returns {string} eg. tab-selector
+     */
+    convertCamelCaseToDashed: function(str) {
+      var val = str.replace(/[A-Z]/g, function(match) {
+        return '-' + match.toLowerCase();
+      });
+      return val.substr(1);
     }
 
   };

--- a/assets/js/lib/utilities.js
+++ b/assets/js/lib/utilities.js
@@ -2,7 +2,7 @@
  * @module utilities
  * @return {Function} utilities
  */
-define([], function() {
+define('utilities', [], function() {
 
   'use strict';
 
@@ -30,7 +30,6 @@ define([], function() {
     /**
      * Converts a CamelCase string to a dashed-one
      * @param {string} str eg. TabSelector
-     * @private
      * @returns {string} eg. tab-selector
      */
     convertCamelCaseToDashed: function(str) {

--- a/assets/js/lib/utilities.js
+++ b/assets/js/lib/utilities.js
@@ -28,16 +28,13 @@ define([], function() {
     },
 
     /**
-     * Converts a CamelCase string to a dashed one
+     * Converts a CamelCase string to a dashed-one
      * @param {string} str eg. TabSelector
      * @private
      * @returns {string} eg. tab-selector
      */
     convertCamelCaseToDashed: function(str) {
-      var val = str.replace(/[A-Z]/g, function(match) {
-        return '-' + match.toLowerCase();
-      });
-      return val.substr(1);
+      return str.replace(/([^\s])([A-Z][a-z])/g, '$1-$2').toLowerCase();
     }
 
   };

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.6.1'
+  VERSION = '5.7.0'
 end

--- a/spec/js/fixtures/DoughBaseComponent.html
+++ b/spec/js/fixtures/DoughBaseComponent.html
@@ -1,0 +1,1 @@
+<div data-dough-component="Foo"></div>

--- a/spec/js/fixtures/DoughBaseComponent.html
+++ b/spec/js/fixtures/DoughBaseComponent.html
@@ -1,1 +1,1 @@
-<div data-dough-component="Foo"></div>
+<div data-dough-component="DoughBaseComponent"></div>

--- a/spec/js/fixtures/DoughBaseComponentExtended.html
+++ b/spec/js/fixtures/DoughBaseComponentExtended.html
@@ -1,0 +1,1 @@
+<div data-dough-component="ExtendedComponent"></div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -1,12 +1,12 @@
 var allTestFiles = [];
 var TEST_REGEXP = /(spec|test)\.js$/i;
 
-var pathToModule = function (path) {
+var pathToModule = function(path) {
   return path.replace(/^\/base\//, '').replace(/\.js$/, '');
 };
 
-Object.keys(window.__karma__.files).forEach(function (file) {
-  if (TEST_REGEXP.test(file)) {
+Object.keys(window.__karma__.files).forEach(function(file) {
+  if(TEST_REGEXP.test(file)) {
     // Normalize paths to RequireJS module names.
     allTestFiles.push(pathToModule(file));
   }

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -19,7 +19,7 @@ require.config({
   // dynamically load all test files
   deps: allTestFiles,
 
-  // we have to kickoff jasmine, as it is asynchronous
+  // we have to kickoff mocha, as it is asynchronous
   callback: window.__karma__.start,
   paths: {
     DoughBaseComponent: 'assets/js/components/DoughBaseComponent',

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -53,6 +53,30 @@ describe('DoughBaseComponent', function() {
       expect(doughBaseComponent.componentName).to.equal('Foo');
       expect(doughBaseComponent.componentAttributeName).to.equal('foo');
     });
+
+    it('should mix the passed config into the component\'s defaultConfig', function() {
+      var doughBaseComponent,
+          config,
+          defaultConfig;
+
+      defaultConfig = {
+        componentName: 'Foo',
+        foo: 'baz',
+        baz: 'qux'
+      };
+
+      config = {
+        foo: 'bar'
+      };
+
+      doughBaseComponent = new this.DoughBaseComponent(this.component, config, defaultConfig);
+
+      expect(doughBaseComponent.config).to.eql({
+        componentName: 'Foo',
+        baz: 'qux',
+        foo: 'bar'
+      });
+    });
   });
 
   describe('initialisation', function () {

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -21,8 +21,8 @@ describe('DoughBaseComponent', function() {
     sandbox.restore();
   });
 
-  describe('init', function() {
-    it('should set the element passed to the constructor', function() {
+  describe('instantiation', function() {
+    it('should cache the element passed to the constructor', function() {
       var doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
 
       expect(doughBaseComponent.$el).to.equal(this.$html);

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -21,7 +21,7 @@ describe('DoughBaseComponent', function() {
 
   describe('instantiation', function() {
     it('should cache the element passed to the constructor', function() {
-      var doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+      var doughBaseComponent = new this.DoughBaseComponent(this.component);
 
       expect(doughBaseComponent.$el).to.equal(this.$html);
     });
@@ -31,27 +31,19 @@ describe('DoughBaseComponent', function() {
           doughBaseComponent;
 
       config = {
-        componentName: 'Foo',
         foo: 'bar'
       };
 
       doughBaseComponent = new this.DoughBaseComponent(this.component, config);
 
-      expect(doughBaseComponent.config).to.eql({ foo: 'bar', componentName: 'Foo' });
+      expect(doughBaseComponent.config).to.eql({ foo: 'bar' });
     });
 
     it('should set the componentName', function() {
-      var config,
-          doughBaseComponent;
+      var doughBaseComponent = new this.DoughBaseComponent(this.component);
 
-      config = {
-        componentName: 'Foo'
-      };
-
-      doughBaseComponent = new this.DoughBaseComponent(this.component, config);
-
-      expect(doughBaseComponent.componentName).to.equal('Foo');
-      expect(doughBaseComponent.componentAttributeName).to.equal('foo');
+      expect(doughBaseComponent.componentName).to.equal('DoughBaseComponent');
+      expect(doughBaseComponent.componentAttributeName).to.equal('dough-base-component');
     });
 
     it('should mix the passed config into the component\'s defaultConfig', function() {
@@ -60,7 +52,6 @@ describe('DoughBaseComponent', function() {
           defaultConfig;
 
       defaultConfig = {
-        componentName: 'Foo',
         foo: 'baz',
         baz: 'qux'
       };
@@ -72,7 +63,6 @@ describe('DoughBaseComponent', function() {
       doughBaseComponent = new this.DoughBaseComponent(this.component, config, defaultConfig);
 
       expect(doughBaseComponent.config).to.eql({
-        componentName: 'Foo',
         baz: 'qux',
         foo: 'bar'
       });
@@ -88,7 +78,7 @@ describe('DoughBaseComponent', function() {
     describe('successful', function () {
       it('should call the resolve (promise) function', function() {
         var spy = sandbox.spy(initialised, 'resolve'),
-            doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+            doughBaseComponent = new this.DoughBaseComponent(this.component);
 
         doughBaseComponent._initialisedSuccess(initialised);
 
@@ -96,18 +86,18 @@ describe('DoughBaseComponent', function() {
       });
 
       it('should stamp an initialised="yes" attribute on the component element', function() {
-        var doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+        var doughBaseComponent = new this.DoughBaseComponent(this.component);
 
         doughBaseComponent._initialisedSuccess(initialised);
 
-        expect(doughBaseComponent.$el).to.have.attr('data-dough-foo-initialised', 'yes');
+        expect(doughBaseComponent.$el).to.have.attr('data-dough-dough-base-component-initialised', 'yes');
       });
     });
 
     describe('failed', function () {
       it('should call the reject (promise) function', function() {
         var spy = sandbox.spy(initialised, 'reject'),
-            doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+            doughBaseComponent = new this.DoughBaseComponent(this.component);
 
         doughBaseComponent._initialisedFailure(initialised);
 
@@ -117,6 +107,12 @@ describe('DoughBaseComponent', function() {
   });
 
   describe('extending', function () {
+    var extendedComponentFixture;
+
+    beforeEach(function() {
+      extendedComponentFixture = $(window.__html__['spec/js/fixtures/DoughBaseComponentExtended.html']);
+    });
+
     it('should allow extending from the DoughBaseComponent', function() {
       var ExtendedComponent,
           extendedComponent;
@@ -125,9 +121,9 @@ describe('DoughBaseComponent', function() {
         ExtendedComponent.baseConstructor.call(this, $el, config);
       };
       this.DoughBaseComponent.extend(ExtendedComponent);
+      ExtendedComponent.componentName = 'ExtendedComponent';
 
-      extendedComponent = new ExtendedComponent(this.$html, { componentName: 'Foo' });
-
+      extendedComponent = new ExtendedComponent(extendedComponentFixture);
       expect(extendedComponent).to.be.instanceof(this.DoughBaseComponent);
     });
   });
@@ -147,7 +143,6 @@ describe('DoughBaseComponent', function() {
         spy = sandbox.stub(this.DoughBaseComponent.prototype, 'fn');
 
         doughBaseComponent = new this.DoughBaseComponent(this.component, {
-          componentName: 'Foo',
           uiEvents: {
             'click [data-dough-base-component-btn]': 'fn'
           }
@@ -169,7 +164,6 @@ describe('DoughBaseComponent', function() {
         spy = sandbox.stub(this.DoughBaseComponent.prototype, 'fn');
 
         doughBaseComponent = new this.DoughBaseComponent(this.component, {
-          componentName: 'Foo',
           uiEvents: {
             'click [data-dough-base-component-btn]': 'fn'
           }

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -1,5 +1,3 @@
-// @todo Add tests for _initialisedSuccess and _initialisedFailure
-
 describe('DoughBaseComponent', function() {
   'use strict';
 
@@ -57,6 +55,43 @@ describe('DoughBaseComponent', function() {
     });
   });
 
+  describe('initialisation', function () {
+    var initialised = {
+      resolve: function() {},
+      reject: function() {}
+    };
+
+    describe('successful', function () {
+      it('should call the resolve (promise) function', function() {
+        var spy = sandbox.spy(initialised, 'resolve'),
+            doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+
+        doughBaseComponent._initialisedSuccess(initialised);
+
+        expect(spy.called).to.be.true;
+      });
+
+      it('should stamp initialised="yes" on the component element', function() {
+        var doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+
+        doughBaseComponent._initialisedSuccess(initialised);
+
+        expect(doughBaseComponent.$el).to.have.attr('data-dough-foo-initialised', 'yes');
+      });
+    });
+
+    describe('failed', function () {
+      it('should call the reject (promise) function', function() {
+        var spy = sandbox.spy(initialised, 'reject'),
+            doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+
+        doughBaseComponent._initialisedFailure(initialised);
+
+        expect(spy.called).to.be.true;
+      });
+    });
+  });
+
   describe('extending', function () {
     it('should allow extending from the DoughBaseComponent constructor', function() {
       var ExtendedComponent,
@@ -84,7 +119,7 @@ describe('DoughBaseComponent', function() {
         var doughBaseComponent,
             spy;
 
-        this.DoughBaseComponent.prototype.fn = $.noop;
+        this.DoughBaseComponent.prototype.fn = function() {};
         spy = sandbox.stub(this.DoughBaseComponent.prototype, 'fn');
 
         doughBaseComponent = new this.DoughBaseComponent(this.component, {
@@ -106,7 +141,7 @@ describe('DoughBaseComponent', function() {
         var doughBaseComponent,
             spy;
 
-        this.DoughBaseComponent.prototype.fn = $.noop;
+        this.DoughBaseComponent.prototype.fn = function() {};
         spy = sandbox.stub(this.DoughBaseComponent.prototype, 'fn');
 
         doughBaseComponent = new this.DoughBaseComponent(this.component, {

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -71,7 +71,7 @@ describe('DoughBaseComponent', function() {
         expect(spy.called).to.be.true;
       });
 
-      it('should stamp initialised="yes" on the component element', function() {
+      it('should stamp an initialised="yes" attribute on the component element', function() {
         var doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
 
         doughBaseComponent._initialisedSuccess(initialised);
@@ -93,7 +93,7 @@ describe('DoughBaseComponent', function() {
   });
 
   describe('extending', function () {
-    it('should allow extending from the DoughBaseComponent constructor', function() {
+    it('should allow extending from the DoughBaseComponent', function() {
       var ExtendedComponent,
           extendedComponent;
 

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -1,0 +1,129 @@
+// @todo Add tests for _initialisedSuccess and _initialisedFailure
+
+describe('DoughBaseComponent', function() {
+  'use strict';
+
+  var sandbox;
+
+  beforeEach(function(done) {
+    var self = this;
+    requirejs(['DoughBaseComponent'], function(DoughBaseComponent) {
+      self.$html = $(window.__html__['spec/js/fixtures/DoughBaseComponent.html']);
+      self.component = self.$html;
+      self.DoughBaseComponent = DoughBaseComponent;
+      sandbox = sinon.sandbox.create();
+      done();
+    });
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+    sandbox.restore();
+  });
+
+  describe('init', function() {
+    it('should set the element passed to the constructor', function() {
+      var doughBaseComponent = new this.DoughBaseComponent(this.component, { componentName: 'Foo' });
+
+      expect(doughBaseComponent.$el).to.equal(this.$html);
+    });
+
+    it('should use the config passed to the constructor', function() {
+      var config,
+          doughBaseComponent;
+
+      config = {
+        componentName: 'Foo',
+        foo: 'bar'
+      };
+
+      doughBaseComponent = new this.DoughBaseComponent(this.component, config);
+
+      expect(doughBaseComponent.config).to.eql({ foo: 'bar', componentName: 'Foo' });
+    });
+
+    it('should set the componentName', function() {
+      var config,
+          doughBaseComponent;
+
+      config = {
+        componentName: 'Foo'
+      };
+
+      doughBaseComponent = new this.DoughBaseComponent(this.component, config);
+
+      expect(doughBaseComponent.componentName).to.equal('Foo');
+      expect(doughBaseComponent.componentAttributeName).to.equal('foo');
+    });
+  });
+
+  describe('extending', function () {
+    it('should allow extending from the DoughBaseComponent constructor', function() {
+      var ExtendedComponent,
+          extendedComponent;
+
+      ExtendedComponent = function($el, config) {
+        ExtendedComponent.baseConstructor.call(this, $el, config);
+      };
+      this.DoughBaseComponent.extend(ExtendedComponent);
+
+      extendedComponent = new ExtendedComponent(this.$html, { componentName: 'Foo' });
+
+      expect(extendedComponent).to.be.instanceof(this.DoughBaseComponent);
+    });
+  });
+
+  describe('events', function () {
+    beforeEach(function () {
+      this.$button = $('<button data-dough-base-component-btn />');
+      this.component.append(this.$button);
+    });
+
+    describe('binding events', function () {
+      it('should bind UI events to the elements specified in the events hash', function() {
+        var doughBaseComponent,
+            spy;
+
+        this.DoughBaseComponent.prototype.fn = $.noop;
+        spy = sandbox.stub(this.DoughBaseComponent.prototype, 'fn');
+
+        doughBaseComponent = new this.DoughBaseComponent(this.component, {
+          componentName: 'Foo',
+          uiEvents: {
+            'click [data-dough-base-component-btn]': 'fn'
+          }
+        });
+
+        this.$button.click();
+        delete this.DoughBaseComponent.prototype.fn;
+
+        expect(spy.called).to.be.true;
+      });
+    });
+
+    describe('unbinding events', function () {
+      it('should unbind any events on the element when the destroy() method is invoked', function() {
+        var doughBaseComponent,
+            spy;
+
+        this.DoughBaseComponent.prototype.fn = $.noop;
+        spy = sandbox.stub(this.DoughBaseComponent.prototype, 'fn');
+
+        doughBaseComponent = new this.DoughBaseComponent(this.component, {
+          componentName: 'Foo',
+          uiEvents: {
+            'click [data-dough-base-component-btn]': 'fn'
+          }
+        });
+
+        this.$button.click();
+        expect(spy.callCount).to.equal(1);
+        doughBaseComponent.destroy();
+
+        this.$button.click();
+        expect(spy.callCount).to.equal(1);
+      });
+    });
+  });
+
+});

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -69,13 +69,13 @@ describe('DoughBaseComponent', function() {
     });
   });
 
-  describe('initialisation', function () {
+  describe('initialisation', function() {
     var initialised = {
       resolve: function() {},
       reject: function() {}
     };
 
-    describe('successful', function () {
+    describe('successful', function() {
       it('should call the resolve (promise) function', function() {
         var spy = sandbox.spy(initialised, 'resolve'),
             doughBaseComponent = new this.DoughBaseComponent(this.component);
@@ -94,7 +94,7 @@ describe('DoughBaseComponent', function() {
       });
     });
 
-    describe('failed', function () {
+    describe('failed', function() {
       it('should call the reject (promise) function', function() {
         var spy = sandbox.spy(initialised, 'reject'),
             doughBaseComponent = new this.DoughBaseComponent(this.component);
@@ -106,7 +106,7 @@ describe('DoughBaseComponent', function() {
     });
   });
 
-  describe('extending', function () {
+  describe('extending', function() {
     var extendedComponentFixture;
 
     beforeEach(function() {
@@ -128,13 +128,13 @@ describe('DoughBaseComponent', function() {
     });
   });
 
-  describe('events', function () {
-    beforeEach(function () {
+  describe('events', function() {
+    beforeEach(function() {
       this.$button = $('<button data-dough-base-component-btn />');
       this.component.append(this.$button);
     });
 
-    describe('binding events', function () {
+    describe('binding events', function() {
       it('should bind UI events to the elements specified in the events hash', function() {
         var doughBaseComponent,
             spy;
@@ -155,7 +155,7 @@ describe('DoughBaseComponent', function() {
       });
     });
 
-    describe('unbinding events', function () {
+    describe('unbinding events', function() {
       it('should unbind any events on the element when the destroy() method is invoked', function() {
         var doughBaseComponent,
             spy;

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -1,13 +1,6 @@
-describe('componentLoader', function() {
+describe('componentLoader', function(utilities) {
 
   'use strict';
-
-  function convertCamelCaseToDashed(str) {
-    var val = str.replace(/[A-Z]/g, function(match) {
-      return '-' + match.toLowerCase();
-    });
-    return val.substr(1);
-  }
 
   beforeEach(function(done) {
     var self = this;
@@ -16,8 +9,9 @@ describe('componentLoader', function() {
         range: true
       }
     };
-    requirejs(['componentLoader'], function(componentLoader) {
+    requirejs(['componentLoader', 'utilities'], function(componentLoader, utilities) {
       self.componentLoader = componentLoader;
+      self.utilities = utilities;
       done();
     });
   });
@@ -39,7 +33,8 @@ describe('componentLoader', function() {
     it('should initialize all components in the DOM', function() {
       var allInitialised = true,
           $component,
-          componentNames;
+          componentNames,
+          self = this;
 
       // NOTE: components add a "data-dough-<componentName>-initialised='yes'" attribute to themselves once
       // they have successfully initialised
@@ -47,7 +42,7 @@ describe('componentLoader', function() {
         $component = $(this);
         componentNames = $component.attr('data-dough-component').split(' ');
         $.each(componentNames, function(idx, componentName) {
-          componentName = convertCamelCaseToDashed(componentName);
+          componentName = self.utilities.convertCamelCaseToDashed(componentName);
           if (!$component.is('[data-dough-' + componentName + '-initialised="yes"]')) {
             allInitialised = false;
             return false;
@@ -78,7 +73,7 @@ describe('componentLoader', function() {
       var $deferredComponent = this.$html.find('[data-dough-component][data-dough-defer]').eq(0);
 
       this.componentLoader.init(this.$html, true).then(function() {
-        expect($deferredComponent.is('[data-dough-' + convertCamelCaseToDashed($deferredComponent.attr('data-dough-component')) + '-initialised="yes"]')).to.be.true;
+        expect($deferredComponent.is('[data-dough-range-input-initialised="yes"]')).to.be.true;
         done();
       });
     });

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -1,4 +1,4 @@
-describe('componentLoader', function(utilities) {
+describe('componentLoader', function() {
 
   'use strict';
 

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -2,6 +2,13 @@ describe('componentLoader', function() {
 
   'use strict';
 
+  function convertCamelCaseToDashed(str) {
+    var val = str.replace(/[A-Z]/g, function(match) {
+      return '-' + match.toLowerCase();
+    });
+    return val.substr(1);
+  }
+
   beforeEach(function(done) {
     var self = this;
     window.Modernizr = {
@@ -40,6 +47,7 @@ describe('componentLoader', function() {
         $component = $(this);
         componentNames = $component.attr('data-dough-component').split(' ');
         $.each(componentNames, function(idx, componentName) {
+          componentName = convertCamelCaseToDashed(componentName);
           if (!$component.is('[data-dough-' + componentName + '-initialised="yes"]')) {
             allInitialised = false;
             return false;
@@ -70,7 +78,7 @@ describe('componentLoader', function() {
       var $deferredComponent = this.$html.find('[data-dough-component][data-dough-defer]').eq(0);
 
       this.componentLoader.init(this.$html, true).then(function() {
-        expect($deferredComponent.is('[data-dough-' + $deferredComponent.attr('data-dough-component') + '-initialised="yes"]')).to.be.true;
+        expect($deferredComponent.is('[data-dough-' + convertCamelCaseToDashed($deferredComponent.attr('data-dough-component')) + '-initialised="yes"]')).to.be.true;
         done();
       });
     });

--- a/spec/js/tests/utilities_spec.js
+++ b/spec/js/tests/utilities_spec.js
@@ -33,4 +33,10 @@ describe('utilities', function() {
 
   });
 
+  describe('convertCamelCaseToDashed', function () {
+    it('should convert a camel cased string into a dash-separated string', function() {
+      expect(this.mod.convertCamelCaseToDashed('FooBar')).to.equal('foo-bar');
+    });
+  });
+
 });

--- a/spec/js/tests/utilities_spec.js
+++ b/spec/js/tests/utilities_spec.js
@@ -33,9 +33,11 @@ describe('utilities', function() {
 
   });
 
-  describe('convertCamelCaseToDashed', function () {
+  describe('convertCamelCaseToDashed', function() {
     it('should convert a camel cased string into a dash-separated string', function() {
       expect(this.mod.convertCamelCaseToDashed('FooBar')).to.equal('foo-bar');
+      expect(this.mod.convertCamelCaseToDashed('FOOBar')).to.equal('foo-bar');
+      expect(this.mod.convertCamelCaseToDashed('FooBarBaz')).to.equal('foo-bar-baz');
     });
   });
 


### PR DESCRIPTION
This PR accomplishes the following:
* Enables a component to be instantiated using its constructor and stamped (`new FooComponent()`) without using `componentLoader`. Before initialising a component directly would return stamp `data-dough-undefined-initialised="yes"`. It now properly sets `data-dough-foo-initialised="yes"`. It does this by moving responsibility of setting the `componentName` to `DoughBaseComponent`. See https://github.com/moneyadviceservice/dough/issues/218 for the original bug. 
* Adds `componentName`'s to default Dough components
* Adds specs for DoughBaseComponent