### PR TITLE
Add focusTarget config to Collapsable

### DIFF
--- a/assets/js/components/Collapsable.js
+++ b/assets/js/components/Collapsable.js
@@ -23,7 +23,8 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
   var CollapsableProto,
       defaultConfig = {
         hideOnBlur: false,
-        forceTo: false
+        forceTo: false,
+        focusTarget: true
       },
       selectors = {
         activeClass: 'is-active',
@@ -130,7 +131,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
    * Toggle the element
    * @param  {[type]} forceTo Supply 'show' or 'hide' to
    * explicitly set, otherwise will automatically toggle
-   * @param {boolean} [focusTarget] - whether to focus the panel
+   * @param {boolean} [focusTarget] - whether to focus the panel. Defaults to `config.focusTarget`
    * @return {[type]}         [description]
    */
   CollapsableProto.toggle = function(forceTo, focusTarget) {
@@ -157,7 +158,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
       label = this.i18nStrings.close;
       expandedLabel = 'true';
       iconClass = selectors.iconClassClose;
-      if (focusTarget !== false) {
+      if (focusTarget !== false && this.config.focusTarget) {
         this.$target
             .attr('tabindex', -1)
             .focus();

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.2.1'
+  VERSION = '5.3.0'
 end

--- a/spec/js/fixtures/Collapsable.html
+++ b/spec/js/fixtures/Collapsable.html
@@ -26,3 +26,23 @@
   </h2>
   <div class="target" data-dough-collapsable-target="1">Content</div>
 </div>
+
+<div class="fixture" id="fixture-4">
+  <h2 class="trigger"
+    data-dough-component="Collapsable"
+    data-dough-collapsable-trigger="1"
+    data-dough-collapsable-config='{"focusTarget": false}'>
+    Heading
+  </h2>
+  <div class="target" data-dough-collapsable-target="1">Content</div>
+</div>
+
+<div class="fixture" id="fixture-5">
+  <h2 class="trigger"
+    data-dough-component="Collapsable"
+    data-dough-collapsable-trigger="1"
+    data-dough-collapsable-config='{"focusTarget": true}'>
+    Heading
+  </h2>
+  <div class="target" data-dough-collapsable-target="1">Content</div>
+</div>

--- a/spec/js/tests/Collapsable_spec.js
+++ b/spec/js/tests/Collapsable_spec.js
@@ -110,4 +110,41 @@ describe('Visibility toggler', function() {
   });
 
 
+  describe('Panel focussed after opening by default', function() {
+    beforeEach(function(done) {
+      var fixtureHTML = $(window.__html__['spec/js/fixtures/Collapsable.html']).filter('#fixture-1').html();
+      this.beforeEachHook.call(this, done, fixtureHTML);
+    });
+
+    it('collapsable target should be focussed', function() {
+      this.$trigger.click();
+      expect(this.$target[0]).to.equal(document.activeElement);
+    });
+  });
+
+
+  describe('Panel not focussed after opening', function() {
+    beforeEach(function(done) {
+      var fixtureHTML = $(window.__html__['spec/js/fixtures/Collapsable.html']).filter('#fixture-4').html();
+      this.beforeEachHook.call(this, done, fixtureHTML);
+    });
+
+    it('collapsable target should not be focussed', function() {
+      this.$trigger.click();
+      expect(this.$target[0]).to.not.equal(document.activeElement);
+    });
+  });
+
+
+  describe('Panel focussed after opening', function() {
+    beforeEach(function(done) {
+      var fixtureHTML = $(window.__html__['spec/js/fixtures/Collapsable.html']).filter('#fixture-5').html();
+      this.beforeEachHook.call(this, done, fixtureHTML);
+    });
+
+    it('collapsable target should be focussed', function() {
+      this.$trigger.click();
+      expect(this.$target[0]).to.equal(document.activeElement);
+    });
+  });
 });


### PR DESCRIPTION
The current behaviour of Collapsable is to focus the target when opened. Allow this behaviour to be overridden with `config.focusTarget`