### PR TITLE
Add validation error prefix

### DIFF
--- a/app/views/dough/forms/builders/validation/_errors_for_field.html.erb
+++ b/app/views/dough/forms/builders/validation/_errors_for_field.html.erb
@@ -1,5 +1,5 @@
 <div class="js-inline-error">
-  <p class="validation-summary__error" id="error-<%= error[:number] %>">
+  <p class="validation-summary__error" id="error-<%= error_prefix %>-<%= error[:number] %>">
     <%= error[:number] %>. <%= error[:message].html_safe %>
   </p>
 </div>

--- a/app/views/dough/forms/builders/validation/_summary_for_errors.html.erb
+++ b/app/views/dough/forms/builders/validation/_summary_for_errors.html.erb
@@ -2,7 +2,7 @@
   <div class="validation-summary__content-container">
     <p class="validation-summary__title"><%= t('dough.forms.validation.summary.title') %></p>
     <ol class="validation-summary__list" data-dough-validation-summary-list>
-      <%= render partial: 'summary_for_errors_li', collection: errors, as: 'error' %>
+      <%= render partial: 'summary_for_errors_li', collection: errors, as: 'error', locals: { error_prefix: error_prefix } %>
     </ol>
   </div>
 </div>

--- a/app/views/dough/forms/builders/validation/_summary_for_errors_li.html.erb
+++ b/app/views/dough/forms/builders/validation/_summary_for_errors_li.html.erb
@@ -2,6 +2,6 @@
   <% if error[:field] == :base %>
     <%= error[:message].html_safe %>
   <% else %>
-    <%= link_to(error[:message], "#error-#{error[:number]}") %>
+    <%= link_to(error[:message], "#error-#{error_prefix}-#{error[:number]}") %>
   <% end %>
 </li>

--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -157,7 +157,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     $.each(this.errors, $.proxy(function(errorIndex, fieldGroupValidity) {
       fieldName = fieldGroupValidity.name;
-      summaryHTML += '<li class="' + this.config.validationSummaryErrorClass + '"><a href="#error-' + fieldName + '">' + fieldGroupValidity.message + '</a></li>';
+      summaryHTML += '<li class="' + this.config.validationSummaryErrorClass + '"><a href="#' + this._getInlineErrorID(fieldName) + '">' + fieldGroupValidity.message + '</a></li>';
     }, this));
 
     this.$el.find('[' + this.config.validationSummaryListAttribute + ']').html(summaryHTML);
@@ -229,7 +229,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @return {String}         The inline error ID
    */
   Validation.prototype._getInlineErrorID = function(fieldName) {
-    return 'error-' + fieldName;
+    var formID = this.$el.attr('id');
+    return 'error-' + (formID ? formID + '-' : '') + fieldName;
   };
 
   /**

--- a/lib/dough/forms/builders/validation.rb
+++ b/lib/dough/forms/builders/validation.rb
@@ -10,14 +10,14 @@ module Dough
         include ActionView::Helpers::TranslationHelper
 
         def validation_summary
-          render 'summary_for_errors', errors: errors
+          render 'summary_for_errors', errors: errors, error_prefix: error_prefix
         end
 
         def errors_for(subject = nil, field)
           subject ||= object
           filtered_errors = errors.select { |hash| hash[:object] == subject && hash[:field] == field }
 
-          render partial: 'errors_for_field', collection: filtered_errors, as: 'error'
+          render partial: 'errors_for_field', collection: filtered_errors, as: 'error', locals: { error_prefix: error_prefix }
         end
 
         def validates(*models)
@@ -69,6 +69,12 @@ module Dough
               end
             end
           end
+        end
+
+        def error_prefix
+          @options
+            .try { |options| options[:html] }
+            .try { |html| html[:id] } || object_name
         end
       end
 

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.3.0'
+  VERSION = '5.4.0'
 end

--- a/spec/js/fixtures/Validation/WithFormID.html
+++ b/spec/js/fixtures/Validation/WithFormID.html
@@ -1,0 +1,14 @@
+<div>
+  <form data-dough-component="Validation" class="form" action="/test" id="test_form_0" novalidate>
+    <div class="form__row">
+      <input type="text" name="name" id="input" value=""
+
+      data-dough-validation-empty="Please provide your name"
+      aria-required
+      required>
+    </div>
+
+    <input type="submit" id="submit">
+
+  </form>
+</div>

--- a/spec/js/tests/Validation_spec.js
+++ b/spec/js/tests/Validation_spec.js
@@ -67,8 +67,6 @@ describe('Validation', function() {
     });
   });
 
-
-
   // Basic required field
   describe('with a required field', function() {
     beforeEach(function(done) {
@@ -187,6 +185,44 @@ describe('Validation', function() {
       validation.$el.submit();
 
       expect($validationSummaryList.find('li').length).to.equal(0);
+    });
+  });
+
+  // Basic required field
+  describe('with a form ID', function() {
+    beforeEach(function(done) {
+      var self = this;
+      requirejs(
+          ['jquery', 'Validation'],
+          function($, Validation) {
+            self.$html = $(window.__html__['spec/js/fixtures/Validation/WithFormID.html']).appendTo('body');
+            self.component = self.$html.find('[data-dough-component="Validation"]');
+            self.Validation = Validation;
+            done();
+          }, done);
+    });
+
+    afterEach(function() {
+      this.$html.remove();
+    });
+
+    it('references the inline error with the aria-describedby attribute on the input when invalid', function() {
+      var validation = new this.Validation(this.component).init(),
+          $input = validation.$el.find('#input');
+
+      focusInOut($input);
+
+      expect($input.attr('aria-describedby').indexOf('error-test_form_0-name')).not.to.equal(-1);
+    });
+
+    it('removes references to the inline error from aria-describedby when valid', function() {
+      var validation = new this.Validation(this.component).init(),
+          $input = validation.$el.find('#input');
+
+      focusInOut($input);
+      $input.val('test').keyup();
+
+      expect($input.attr('aria-describedby').indexOf('error-test_form_0-name')).to.equal(-1);
     });
   });
 

--- a/spec/lib/dough/forms/builders/validation_spec.rb
+++ b/spec/lib/dough/forms/builders/validation_spec.rb
@@ -81,6 +81,20 @@ describe Dough::Forms::Builders::Validation do
       expect(validation_summary).to include('Field one is not a number')
     end
 
+    context 'when form has an ID' do
+      subject(:form_builder) { described_class.new(:model, model, {}, {html: {id: 'form_id'}}) }
+
+      it 'uses the form id to generate the error links' do
+        expect(validation_summary).to include('#error-form_id-1')
+      end
+    end
+
+    context 'when form has no ID' do
+      it 'uses the model name to generate the error links' do
+        expect(validation_summary).to include('#error-model-1')
+      end
+    end
+
     context 'lists errors in order' do
       #FIXME: Don't like having to call a private method to have to verify list order
       let(:errors) { form_builder.send(:errors) }
@@ -115,6 +129,20 @@ describe Dough::Forms::Builders::Validation do
         model.errors[field].each do |error|
           expect(subject.errors_for(field)).to include(error)
         end
+      end
+    end
+
+    context 'when form has an ID' do
+      subject(:form_builder) { described_class.new(:model, model, {}, {html: {id: 'form_id'}}) }
+
+      it 'uses the form ID to generate the error id' do
+        expect(subject.errors_for(:field_one)).to include('error-form_id-1')
+      end
+    end
+
+    context 'when form has no ID' do
+      it 'uses the model name to generate the error id' do
+        expect(subject.errors_for(:field_one)).to include('error-model-1')
       end
     end
   end


### PR DESCRIPTION
This PR makes the form validation functionality, across both ruby and JS, use the form ID when generating the IDs for error labels. If there's no form ID (such as when we're using `fields_for` in a form) it falls back to `object_name`.

So, in the case of Ruby, instead of `#error-1`, we get `#error-form_id-1`.

And, in the case of JS, instead of `#error-field_name` we get `#error-form_id-field_name`.

This helps us avoid duplicate IDs (and links to those IDs) when we have more than one form on the same page.

Background, from slack:

> __Caden Lovelace:__
> I'm working on a form with `fields_for`. Both the form and the `fields_for` use `Dough::Forms::Builders::Validation`. And they both use `form#validation_summary` to display errors
> And each error in the validation summary has an ID link, like `#error-1` to link to the individual error fields
> But the validation summary in the `fields_for` starts again at `#error-1`, which means it links to the first error in the parent form. The in-form validations also start again, at `#error-1`, so we get duplicate IDs too.
> Is there an established way of dealing with this situation?
> e.g.  
> ![image](https://cloud.githubusercontent.com/assets/1007202/6713885/150e2db4-cd8d-11e4-9410-be6b4514c2e0.png)

> __Phil Lee__
> I can't see a workaround. A change could be made to dough to accept a string/namespce into the form builder which could be prefixed to the error id

I thought using the form ID with a fallback to the object name _might_ be better than adding an attribute to the form, but I'm not completely happy with this either. Any thoughts/alternative ideas are welcome.