### PR TITLE
[WIP] Dough theme updates

### DIFF
--- a/assets/stylesheets/basic.scss
+++ b/assets/stylesheets/basic.scss
@@ -1,16 +1,16 @@
 @import 'normalize-css/normalize';
 
 body, .dough {
-  color: #555;
+  color: #000;
   font: normal 16px/1.375, "Helvetica Neue", Helvetica, Arial, serif;
 }
 
 h1 {
-  color: #61a612; //$color-green-secondary
+  color: #000;
 }
 
 h2, h3, h4, h5, h6 {
-  color: #388426; //$color-green-dark
+  color: #000;
 }
 
 h1 {

--- a/assets/stylesheets/components/common/_button.scss
+++ b/assets/stylesheets/components/common/_button.scss
@@ -1,10 +1,11 @@
 .button {
   @include inline-block;
+  background: $color-button-default;
+  border-radius: 5px;
   margin-bottom: 0;
   line-height: inherit;
   text-align: center;
   white-space: nowrap;
-  background: $color-button-default;
   color: $color-button-text;
   cursor: pointer;
   filter: none;
@@ -19,6 +20,8 @@
 
   &.is-disabled,
   &[disabled] {
+    background: $color-button-default-background-disabled;
+    color: $color-button-text-disabled;
     pointer-events: none;
     cursor: not-allowed;
   }

--- a/assets/stylesheets/components/common/_callout.scss
+++ b/assets/stylesheets/components/common/_callout.scss
@@ -1,9 +1,27 @@
 .callout {
-  // prevents the callout from collapsing.
-  // Note: extending clearfix instead of including it does not work.
   @include clearfix();
-}
+  padding: $baseline-unit*3 0 0 0;
+  margin: $baseline-unit*4 0;
+  border-radius: 5px;
+  background-color: $color-callout-background;
 
-.callout--instructional {
-  background-color: $color-panel-background;
+  h3 {
+    @extend %heading-extra-small;
+    margin: 0 $baseline-unit*3 $baseline-unit;
+    text-transform: capitalize;
+  }
+
+  p {
+    @extend %type-callout;
+    margin: 0 $baseline-unit*3 $baseline-unit*3 $baseline-unit*3;
+  }
+
+  .editorial & {
+
+    @include respond-to($mq-l) {
+      @include column(3.5, 7);
+      float: right;
+      margin-bottom: $baseline-unit*2;
+    }
+  }
 }

--- a/assets/stylesheets/components/common/_callout.scss
+++ b/assets/stylesheets/components/common/_callout.scss
@@ -15,13 +15,4 @@
     @extend %type-callout;
     margin: 0 $baseline-unit*3 $baseline-unit*3 $baseline-unit*3;
   }
-
-  .editorial & {
-
-    @include respond-to($mq-l) {
-      @include column(3.5, 7);
-      float: right;
-      margin-bottom: $baseline-unit*2;
-    }
-  }
 }

--- a/assets/stylesheets/components/common/_form.scss
+++ b/assets/stylesheets/components/common/_form.scss
@@ -1,3 +1,7 @@
+.form__row {
+  margin-bottom: $baseline-unit*3;
+}
+
 .form__row--is-errored {
   label {
     color: $color-validation-text;
@@ -83,6 +87,7 @@
 }
 
 .form__input-outline {
+  border: 1px solid $color-input-border-color;
   display: block;
   bottom: 0;
   left: 0;
@@ -90,4 +95,8 @@
   right: 0;
   top: 0;
   z-index: 1;
+}
+
+.form__input-container .form__input:focus ~ .form__input-outline {
+  border: 2px solid $color-input-focus-border-color;
 }

--- a/assets/stylesheets/components/common/_inset-block.scss
+++ b/assets/stylesheets/components/common/_inset-block.scss
@@ -1,9 +1,5 @@
 .inset-block {
   margin: $baseline-unit*2 0 $baseline-unit*3 0;
-
-  @include respond-to($mq-s) {
-    margin: $baseline-unit*2 0 $baseline-unit*5 0;
-  }
 }
 
 .inset-block__content-container {

--- a/assets/stylesheets/components/common/_inset-block.scss
+++ b/assets/stylesheets/components/common/_inset-block.scss
@@ -1,0 +1,18 @@
+.inset-block {
+  margin: $baseline-unit*2 0 $baseline-unit*3 0;
+
+  @include respond-to($mq-s) {
+    margin: $baseline-unit*2 0 $baseline-unit*5 0;
+  }
+}
+
+.inset-block__content-container {
+  border-left: 10px solid $color-inset-block-border;
+  padding-left: 10px;
+  @include inline-block;
+  padding-right: $baseline-unit*3;
+}
+
+.inset-block__text {
+  margin-bottom: 0;
+}

--- a/assets/stylesheets/components/common/_tables.scss
+++ b/assets/stylesheets/components/common/_tables.scss
@@ -1,0 +1,65 @@
+// Tables wrapped in a .table-wrapper will scroll horizontally if the table is bigger than the space available for it.
+//
+// Styleguide Scrollable Table
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-wrapper > .table > thead > tr > th,
+.table-wrapper > .table > tbody > tr > th,
+.table-wrapper > .table > tfoot > tr > th,
+.table-wrapper > .table > thead > tr > td,
+.table-wrapper > .table > tbody > tr > td,
+.table-wrapper > .table > tfoot > tr > td {
+  white-space: nowrap;
+}
+
+table {
+  @extend %type-table;
+  text-align: left;
+  margin: $baseline-unit*4 0;
+
+  > p {
+    // NOTE that this is here to override sloppy formatting in the tables where p tags force a large font size.
+    @extend %type-table;
+  }
+
+}
+
+.table--full-width {
+  width: 100%;
+}
+
+
+tr:nth-child(even) {
+  background-color: $color-table-background-alt;
+}
+
+thead > tr {
+  background-color: $color-table-background;
+}
+
+tbody th {
+  text-align: left;
+}
+
+th, td {
+  vertical-align: top;
+  padding: $baseline-unit*2;
+  border-right: 1px solid $color-table-border;
+  width: auto;
+  &:last-child {
+    border-right: 0;
+  }
+}
+
+th,
+th > p {
+  font-weight: 500;
+  // NOTE that this is here to override sloppy formatting in the tables where p tags is not bolded.
+}

--- a/assets/stylesheets/components/common/_validation_summary.scss
+++ b/assets/stylesheets/components/common/_validation_summary.scss
@@ -5,12 +5,24 @@
 }
 
 .validation-summary__content-container {
-  @extend .is-errored;
   background: $color-validation-summary-background;
+  border-left: 10px solid $color-validation-border;
+  color: $color-validation-text;
+  padding: $baseline-unit 18px;
 }
 
 .validation-summary__title {
+  font-weight: 700;
 }
 
 .validation-summary__list {
+  margin: $baseline-unit*2 0;
+
+  a {
+     color:$color-validation-text;
+     text-decoration:none;
+     &:hover, &:focus {
+      text-decoration:underline;
+     }
+  }
 }

--- a/assets/stylesheets/components/optional/_tabular_tooltip.scss
+++ b/assets/stylesheets/components/optional/_tabular_tooltip.scss
@@ -16,7 +16,7 @@
       margin-left: 100%; // absolutely position tooltip a little to the right of parent element
       width: 250px; // no height - tooltip will be as tall as required to fit all the text
       background: #fff; // pale yellow
-      border: 1px solid $color-grey-paleo;
+      border: 1px solid $color-tabular-tooltip-border;
       color: #666; // override default blue link colour
       padding: 0.8em 1em;
     }

--- a/assets/stylesheets/lib/_variables.scss
+++ b/assets/stylesheets/lib/_variables.scss
@@ -2,8 +2,6 @@ $base-font-size: 16 !default;
 
 $baseline-unit: if($responsive, 0.375rem, 6px);
 
-$sprite-background-size: 550px;
-
 // Core colors --------------------------------------------------------------------------- //
 // IMPORTANT: These should never be referenced directly within a Sass partial
 // Instead, create a useful and semantic reference to it i.e. $color-nav-background: $color-black;

--- a/assets/stylesheets/lib/_variables.scss
+++ b/assets/stylesheets/lib/_variables.scss
@@ -82,14 +82,6 @@ $color-panel-footer-background: $color-white !default;
 $color-callout-background: lighten($color-shamrock, 20%) !default;
 $color-callout-instructional-background: $color-alto !default;
 
-// Search
-$color-search-border: $color-alto !default;
-$color-search-text: $color-black !default;
-$color-search-input-background: $color-white !default;
-$color-search-button-focus-background: $color-shamrock !default;
-$color-search-button-focus-foreground: $color-white !default;
-$color-header-buttons: $color-shamrock !default;
-
 // Form Validation
 $color-validation-border: lighten($color-sunglo, 20%) !default;
 $color-validation-text: $color-sunglo !default;

--- a/assets/stylesheets/lib/_variables.scss
+++ b/assets/stylesheets/lib/_variables.scss
@@ -6,7 +6,7 @@ $sprite-background-size: 550px;
 
 // Core colors --------------------------------------------------------------------------- //
 // IMPORTANT: These should never be referenced directly within a Sass partial
-// Instead, create a component variable reference e.g. $color-nav-background: $color-black;
+// Instead, create a useful and semantic reference to it i.e. $color-nav-background: $color-black;
 
 // Neutrals
 $color-black: #000 !default;
@@ -107,36 +107,30 @@ $color-input-focus-border-color: $color-yellow-sea !default;
 $color-input-disabled-background: lighten($color-silver, 60%) !default;
 $color-input-disabled-text-color: lighten($color-black, 60%) !default;
 
-$color-fieldset-legend-fg: $color-shamrock;
+$color-fieldset-legend-fg: $color-shamrock !default;
 
 $color-range-border: $color-alto !default;
 $color-range-background: $color-alto !default;
 $color-range-thumb-background: $color-white !default;
 
-// Inset block
-$color-inset-block-border: $color-cerulean;
-
 // Input button
-$input-button-height: $input-height;
+$input-button-height: $input-height !default;
 
+// Inset block
+$color-inset-block-border: $color-cerulean !default;
+
+// Tab Selector
 $color-tab-selector-background-active: lighten($color-shamrock, 10%) !default;
-$color-tab-selector-background: $color-white;
-$color-tab-selector-border: $color-shamrock;
-$color-tab-selector-text: $color-black;
+$color-tab-selector-background: $color-white !default;
+$color-tab-selector-border: $color-shamrock !default;
+$color-tab-selector-text: $color-black !default;
 
 // Color tabular tooltip
-$color-tabular-tooltip-border: $color-alto;
+$color-tabular-tooltip-border: $color-alto !default;
 
 // Borders
 $default-border-thin: 1px solid $color-silver !default;
 $default-border-thick: 3px solid $color-silver !default;
-
-// Global alerts
-$color-global-alert-message-bg: $color-alto;
-$color-global-alert-default: $color-shamrock;
-$color-global-alert-warning: $color-yellow-sea;
-$color-global-alert-error: $color-sunglo;
-
 
 // -------------- DEPRECATED VARIABLES -----------------//
 $border-radius-button: 4px;

--- a/assets/stylesheets/lib/_variables.scss
+++ b/assets/stylesheets/lib/_variables.scss
@@ -4,193 +4,138 @@ $baseline-unit: if($responsive, 0.375rem, 6px);
 
 $sprite-background-size: 550px;
 
-// COLOURS
+// Core colors --------------------------------------------------------------------------- //
+// IMPORTANT: These should never be referenced directly within a Sass partial
+// Instead, create a component variable reference e.g. $color-nav-background: $color-black;
+
+// Neutrals
+$color-black: #000 !default;
 $color-white: #fff !default;
-$color-off-white: #f5f7f7 !default;
-$color-white-translucent: rgba(255, 255, 255, 0.2) !default;
-$color-white-translucent-fallback: rgb(255, 255, 255) !default;
-$color-transparent: transparent !default;
 
-$color-black: #2e3030 !default;
-$color-black-two: #4e4f4f !default;
-$color-grey-primary: #6a6d6d !default;
+// Greens
+$color-shamrock: #4ed4ac !default;
 
-$color-green-primary: #428513 !default;
-$color-green-secondary: #61a612 !default;
-$color-green-tertiary: #115329 !default;
-$color-green-quaternary: #337018 !default;
-$color-green-quinary: #2d6a1e;
-$color-green-six: #76B72A;
+// Greys
+$color-silver: #bababa !default;
+$color-alto: #dbdbdb !default;
 
-$color-green-paler: #f5f7f8 !default;
-$color-green-pale: #f7fbec !default;
-$color-green-light: #b9dd48 !default;
-$color-green-medium: #81c724 !default;
-$color-green-bright: #adcf3f !default;
-$color-green-dark: #388426 !default;
-$color-green-one: #77bf24 !default;
-$color-green-two: #20600f !default;
-$color-green-three: #f7fbed !default;
+// Reds (use solely for error states)
+$color-sunglo: #d11d32 !default;
 
-$color-teal-light: #109e89 !default;
-$color-teal-dark: #0e7f6c !default;
+// Oranges
+$color-yellow-sea: #ffae00 !default;
 
-$color-blue-pale: #ebf2f5 !default;
-$color-blue-light: #e6f2f7 !default;
-$color-blue-medium: #1f6faa !default;
-$color-blue-bright: #007eae !default;
-$color-blue-dark: #18507a !default;
-$color-blue-extra-dark: #0a4358 !default;
+// Blues
+$color-cerulean: #02a4d3 !default;
 
-$color-grey-palest: #dce3e1 !default;
-$color-grey-paler: #f2f4f4 !default;
-$color-grey-pale: #edf0f0 !default;
-$color-grey-paleo: #ecf0ef !default;
-$color-grey-normal: #d1d5d5 !default;
-$color-grey-seven: #929494 !default;
-$color-grey-eight: #dce0e0 !default;
-$color-grey-nine: #e2e2e2 !default;
-$color-grey-ten: #f4f4f4 !default;
-$color-grey-light: #a8b2ba !default;
-$color-grey-medium-dark: #6a6d6d !default;
-$color-grey-medium: #526675 !default;
-$color-grey-dark: #394752 !default;
-
-$color-grey-corduroy: #686C6C !default;
-$color-grey-concrete: #F3F3F3 !default;
-
-$color-bluegrey-dark: #96b4c0 !default;
-$color-bluegrey-medium: #cbdae0 !default;
-$color-bluegrey-light: #dae1df !default;
-
-$color-pink-light: #fdf0f2 !default;
-$color-pink-medium: #e43c8a !default;
-$color-pink-dark: #bf2682 !default;
-
-$color-red-light: #e06e72 !default;
-$color-red-medium: #d11d32 !default;
-$color-red-bright: #ea4c49 !default;
-$color-red-dark: #af2745 !default;
-
-$color-orange-medium: #f06431 !default;
-$color-orange-dark: #c95d2d !default;
-
-$color-yellow-light: #ead548 !default;
-$color-yellow-dark: #daaf2d !default;
-
-$color-horizontal-rule: $color-grey-paleo !default;
-
-$color-brand-green: $color-green-six; // logo arch colour
+// -------------------------------------------------------------------------------------- //
 
 // Typography
-$color-heading-default: $color-green-secondary !default;
-$color-heading-medium: $color-green-dark !default;
-$color-text-default: $color-grey-primary !default;
+$color-horizontal-rule: $color-alto !default;
+$color-heading-default: $color-black !default;
+$color-heading-medium: $color-black !default;
+$color-text-default: $color-black !default;
 $color-heading-extra-small: $color-black !default;
 $color-text-icon: $color-white !default;
-$color-paragraph-intro: $color-grey-primary !default;
+$color-paragraph-intro: $color-black !default;
 
 // Default Links
-$color-link-default: $color-blue-medium !default;
-$color-link-visited: $color-blue-dark !default;
-$color-link-focus: $color-blue-light !default;
-
-// Global Colours
-$color-site-bg: $color-green-primary !default;
-$color-heading: $color-green-secondary !default;
+$color-link-default: $color-cerulean !default;
+$color-link-visited: desaturate($color-cerulean, 100%) !default;
+$color-link-focus: darken($color-cerulean, 20%) !default;
 
 // Tables
-$color-table-heading: $color-white !default;
-$color-table-background: $color-grey-nine !default;
-$color-table-background-alt: $color-grey-ten !default;
-$color-table-border: $color-green-one !default;
+$color-table-heading: $color-alto !default;
+$color-table-background: $color-silver !default;
+$color-table-background-alt: $color-alto !default;
+$color-table-border: $color-alto !default;
 
 // Lists
-$color-list-bullet: $color-green-secondary !default;
-$color-list-yes: $color-green-secondary !default;
-$color-list-no: $color-red-dark !default;
+$color-list-bullet: $color-cerulean !default;
+$color-list-yes: $color-shamrock !default;
+$color-list-no: $color-sunglo !default;
 
 // Buttons
 $color-button-text: $color-black !default;
-$color-button-text-disabled: #666969 !default;
+$color-button-text-disabled: lighten($color-black, 60%) !default;
 
-$color-button-default: $color-grey-normal !default;
-$color-button-default-active: #dce0e0 !default;
-$color-button-default-disabled: #e8ebeb !default;
+$color-button-default: $color-silver !default;
+$color-button-default-background-disabled: lighten($color-silver, 10%) !default;
 
-$color-button-default-border: $color-grey-seven !default;
-$color-button-default-border-active: #b5b7b7 !default;
-$color-button-default-border-disabled: #cfd1d1 !default;
+$color-button-default-border: darken($color-yellow-sea, 20%) !default;
+$color-button-default-border-active: darken($color-yellow-sea, 30%) !default;
+$color-button-default-border-disabled: darken($color-yellow-sea, 20%) !default;
 
-$color-button-primary: $color-yellow-light !default;
-$color-button-primary-active: #edde74 !default;
-$color-button-primary-disabled: #f2ebb2 !default;
+$color-button-primary: $color-shamrock !default;
+$color-button-primary-active: lighten($color-shamrock, 20%) !default;
+$color-button-primary-disabled: opacify($color-shamrock, .5) !default;
 
-$color-button-primary-border: $color-yellow-dark !default;
-$color-button-primary-border-active: #e1c260 !default;
-$color-button-primary-border-disabled: #eddfb2 !default;
+$color-button-primary-border: darken($color-shamrock, 20%) !default;
+$color-button-primary-border-active: lighten($color-shamrock, 10%) !default;
+$color-button-primary-border-disabled: opacify($color-shamrock, .5) !default;
 
 // Panels
-$color-panel-background: $color-grey-pale !default;
+$color-panel-background: $color-alto !default;
 $color-panel-footer-background: $color-white !default;
 
 // Callout
-$color-callout-background: $color-green-pale !default;
-$color-callout-instructional-background: $color-grey-pale !default;
+$color-callout-background: lighten($color-shamrock, 20%) !default;
+$color-callout-instructional-background: $color-alto !default;
 
 // Search
-$color-search-border: $color-grey-light !default;
-$color-search-text: $color-grey-medium-dark !default;
-$color-search-input-background: $color-off-white !default;
-$color-search-button-focus-background: $color-green-secondary !default;
+$color-search-border: $color-alto !default;
+$color-search-text: $color-black !default;
+$color-search-input-background: $color-white !default;
+$color-search-button-focus-background: $color-shamrock !default;
 $color-search-button-focus-foreground: $color-white !default;
-$color-header-buttons: $color-green-two !default;
+$color-header-buttons: $color-shamrock !default;
 
 // Form Validation
-$color-validation-border: $color-red-light !default;
-$color-validation-text: $color-red-medium !default;
-$color-validation-summary-background: $color-pink-light !default;
+$color-validation-border: lighten($color-sunglo, 20%) !default;
+$color-validation-text: $color-sunglo !default;
+$color-validation-summary-background: lighten($color-sunglo, 50%) !default;
 
 // Forms
 $input-height: $baseline-unit*5 !default;
 $color-input-text-color: $color-black !default;
 $color-input-background: $color-white !default;
-$color-input-border-color: $color-grey-primary !default;
+$color-input-border-color: $color-silver !default;
 
-$color-input-focus-background: $color-off-white !default;
-$color-input-focus-border-color: $color-green-one !default;
+$color-input-focus-background: $color-white !default;
+$color-input-focus-border-color: $color-yellow-sea !default;
 
-$color-input-disabled-background: $color-grey-concrete !default;
-$color-input-disabled-text-color: $color-grey-corduroy !default;
+$color-input-disabled-background: lighten($color-silver, 60%) !default;
+$color-input-disabled-text-color: lighten($color-black, 60%) !default;
 
-$color-fieldset-legend-fg: $color-green-secondary;
+$color-fieldset-legend-fg: $color-shamrock;
 
-$color-range-border: $color-grey-light !default;
-$color-range-background: $color-grey-palest !default;
+$color-range-border: $color-alto !default;
+$color-range-background: $color-alto !default;
 $color-range-thumb-background: $color-white !default;
 
 // Inset block
-$color-inset-block-border: $color-blue-medium;
+$color-inset-block-border: $color-cerulean;
 
 // Input button
 $input-button-height: $input-height;
 
-$color-tab-selector-background-active: $color-white;
-$color-tab-selector-background: $color-grey-nine;
-$color-tab-selector-border: $color-green-medium;
-$color-tab-selector-text: $color-text-default;
+$color-tab-selector-background-active: lighten($color-shamrock, 10%) !default;
+$color-tab-selector-background: $color-white;
+$color-tab-selector-border: $color-shamrock;
+$color-tab-selector-text: $color-black;
+
+// Color tabular tooltip
+$color-tabular-tooltip-border: $color-alto;
 
 // Borders
-$default-border-thin: 1px solid $color-grey-paleo !default;
-$default-border-thick: 3px solid $color-grey-paleo !default;
+$default-border-thin: 1px solid $color-silver !default;
+$default-border-thick: 3px solid $color-silver !default;
 
 // Global alerts
-$color-global-alert-message-bg: $color-grey-ten;
-$color-global-alert-default: $color-green-one;
-$color-global-alert-warning: $color-yellow-light;
-$color-global-alert-error: $color-red-medium;
-
-
+$color-global-alert-message-bg: $color-alto;
+$color-global-alert-default: $color-shamrock;
+$color-global-alert-warning: $color-yellow-sea;
+$color-global-alert-error: $color-sunglo;
 
 
 // -------------- DEPRECATED VARIABLES -----------------//


### PR DESCRIPTION
Is part of wider changes to tidy up the variables and reduce complexity across the Sass files for Yeast, Dough and the MAS site. 

**Simplifies Dough theme**
* Completely removes the MAS colour scheme from Dough.
* Reduces colour scheme from 70 colours down to 8.

**Adds a base Dough theme**
* Adds a simple Dough colour scheme. 
* Uses named colours.
* Adds back in base styling for various components. When Yeast was created some of the styles had been removed from Dough, leaving the base components looking unfinished. 