### PR TITLE
TP-6422: Fix bug with visibility of tab selector component

### DIFF
--- a/assets/stylesheets/components/optional/_tab_selector.scss
+++ b/assets/stylesheets/components/optional/_tab_selector.scss
@@ -20,7 +20,7 @@
   .js & {
     display: inline-block;
   }
-  [data-dough-tabselector-initialised="yes"] & {
+  [data-dough-tab-selector-initialised="yes"] & {
     visibility: visible;
     &.is-active {
       display: inline-block;


### PR DESCRIPTION

![screen shot 2015-06-16 at 11 02 54](https://cloud.githubusercontent.com/assets/6049076/8180630/2c11e44e-1417-11e5-92c4-0e43f0a3ca1b.png)


- due to a change (https://github.com/moneyadviceservice/dough/commit/8f484b050078d0f52503b4085cc2b8b6ae2df1f1) by Justin back in Feb, the internal name
  of the tab selector component has changed from 'tabselector'
  to 'tab-selector'
- fixes the css which relies on this name