### PR TITLE
TP-6297: Fix IE8 issue with tab selector dough component

### DIFF
--- a/assets/js/lib/mediaQueries.js
+++ b/assets/js/lib/mediaQueries.js
@@ -22,7 +22,8 @@ define(['jquery', 'eventsWithPromises', 'featureDetect', 'jqueryThrottleDebounce
 
   /**
    *
-   * Gets current media query value (set on the `testElement`) and publishes an event `mediaquery:resize` via _eventsWithPromises_.
+   * Gets current media query value (set on the `testElement`) and
+   * publishes an event `mediaquery:resize` via _eventsWithPromises_.
    * @function
    * @param  {Boolean} forceEvent Bypass the `current` and `newSize` and publish the event.
    */
@@ -38,12 +39,14 @@ define(['jquery', 'eventsWithPromises', 'featureDetect', 'jqueryThrottleDebounce
 
   /**
    * Gets current media query value as set using the
-   * Technique explained here: [Write Simple, Elegant and Maintainable Media Queries with Sass](http://davidwalsh.name/device-state-detection-css-media-queries-javascript)
+   * Technique explained here: [Write Simple, Elegant and Maintainable
+   * Media Queries with Sass](http://davidwalsh.name/device-state-detection-css-media-queries-javascript)
    * @function
    * @return {String} mq-xs or mq-s or mq-m or mq-l or mq-xl
    */
   function getSize() {
-    return window.getComputedStyle(testElement[0], ':after').getPropertyValue('content');
+    return featureDetect.mediaQueries ?
+      window.getComputedStyle(testElement[0], ':after').getPropertyValue('content') : 'mq-l';
   }
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -16,5 +16,8 @@
     "requirejs": "latest",
     "jquery": "latest",
     "jqueryThrottleDebounce": "https://github.com/cowboy/jquery-throttle-debounce.git"
+  },
+  "devDependencies": {
+    "squire": "~0.2.0"
   }
 }

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.7.0'
+  VERSION = '5.7.1'
 end

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -37,7 +37,8 @@ require.config({
     eventsWithPromises: 'vendor/assets/bower_components/eventsWithPromises/src/eventsWithPromises',
     rsvp: 'vendor/assets/bower_components/rsvp/rsvp',
     jqueryThrottleDebounce: 'vendor/assets/bower_components/jqueryThrottleDebounce/jquery.ba-throttle-debounce',
-    utilities: 'assets/js/lib/utilities'
+    utilities: 'assets/js/lib/utilities',
+    squire: 'vendor/assets/bower_components/squire/src/Squire'
   },
   shim: {
     modernizr: {

--- a/spec/js/tests/mediaQueries_spec.js
+++ b/spec/js/tests/mediaQueries_spec.js
@@ -34,7 +34,7 @@ describe('mediaQueries - fires JS events when breakpoints are crossed', function
     it('only fires one resize event if initialised twice', function() {
       var spy = sinon.spy();
       self.eventsWithPromises.subscribe('mediaquery:resize', spy);
-      spy.should.have.been.calledOnce;
+      expect(spy).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
- Added check for mediaQuery support when calling
  getSize to ensure JS doesn't break on IE8
- added Squire to bower deps to allow for
  AMD module mocking so we can test behaviour
  with/without mediaQuery support