### PR TITLE
stop event propagation if validation errors

### DIFF
--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -555,6 +555,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     if (this.errors.length) {
       e.preventDefault();
+      e.stopPropagation();
       this._sortErrorsByFieldDisplayOrder().refreshValidationSummary()._showValidationSummary();
     }
   };

--- a/spec/js/tests/Validation_spec.js
+++ b/spec/js/tests/Validation_spec.js
@@ -186,6 +186,35 @@ describe('Validation', function() {
 
       expect($validationSummaryList.find('li').length).to.equal(0);
     });
+
+    it('does not allow event propagation if there are errors', function() {
+      var validation = new this.Validation(this.component).init(),
+          $input = validation.$el.find('#input');
+
+      var additionalEvent;
+      $('form').on('submit', function(event){
+        additionalEvent = event;
+      });
+
+      validation.$el.submit();
+
+      expect(additionalEvent.isPropagationStopped()).to.be.true;
+    });
+
+    it('allows event propagation if there are no errors', function() {
+      var validation = new this.Validation(this.component).init(),
+          $input = validation.$el.find('#input');
+
+      var additionalEvent;
+      $('form').on('submit', function(event){
+        additionalEvent = event;
+      });
+
+      $input.val('test');
+      validation.$el.submit();
+
+      expect(additionalEvent.isPropagationStopped()).to.be.false;
+    });
   });
 
   // Basic required field


### PR DESCRIPTION
This PR adds an additional guard to the submit event handler within `Validation.js`. In the event there are validation errors, the `preventDefault` behaviour will stop a form post from occurring, but it won't halt event bubbling, which in turn won't stop ajax form submissions.