### PR TITLE
id:6501 comment: Removing a bunch of comments in Sass

### DIFF
--- a/assets/stylesheets/components/common/_button.scss
+++ b/assets/stylesheets/components/common/_button.scss
@@ -1,17 +1,3 @@
-// Buttons
-//
-// :hover      - green
-// :focus      - green
-// :active     - green
-// .is-disabled - green
-// .button--primary            - yellow
-// .button--primary:hover      - yellow
-// .button--primary:focus      - yellow
-// .button--primary:active     - yellow
-// .button--primary.is-disabled - yellow
-//
-// Styleguide buttons
-
 .button {
   @include inline-block;
   margin-bottom: 0;
@@ -61,31 +47,15 @@
   }
 }
 
-// Requires the text to be wrapped in a sub-element in order to hide it at small viewport widths
-//
-// Styleguide Direction buttons
-
 .button--compact {
   cursor: pointer;
 }
-
-// Sits alongside a text input. Button height matches text input height.
-//
-// .button--inline-input
-//
-// Styleguide Inline buttons
 
 .button--inline-input {
   height: $input-height;
   line-height: 0;
   vertical-align: top;
 }
-
-// Smaller font / padding
-//
-// .button--small
-//
-// Styleguide Small buttons
 
 .button--small {
   line-height: 1;

--- a/assets/stylesheets/components/common/_form.scss
+++ b/assets/stylesheets/components/common/_form.scss
@@ -1,19 +1,3 @@
-// Forms
-//
-// .form - Default form form container
-// .form__row - Container for form element(s).
-// .form__row--is-errored - Form item error state
-// .form__label-heading - Form item label
-// .form__hint - Provides further information about an input
-// .form__group - Groups multiple form elements - to be used in conjuction with `<fieldset>`
-// .form__group--inline - Displays the items within form__group horizontally
-// .form__group-item - An item within a form group - stacked vertically by default
-// .form__input-container - Wrapper to group and enable formatting on .form__input-label and .form__input elements
-// .form__input-container .form__input - Input within the container group
-// .form__input-container .form__input-label - Provides additional labelling for an `<input>` - there can be multiple labels of any width
-//
-// Styleguide forms
-
 .form__row--is-errored {
   label {
     color: $color-validation-text;

--- a/assets/stylesheets/components/common/_pagination.scss
+++ b/assets/stylesheets/components/common/_pagination.scss
@@ -1,3 +1,0 @@
-// Pagination
-//
-// Styleguide pagination

--- a/assets/stylesheets/components/common/_validation_summary.scss
+++ b/assets/stylesheets/components/common/_validation_summary.scss
@@ -1,7 +1,3 @@
-// Box used to present summary of form validation errors
-//
-// Styleguide validation-summary
-
 .validation-summary {
   &.validation-summary--hidden {
     display:none;

--- a/assets/stylesheets/components/optional/_form_input_range.scss
+++ b/assets/stylesheets/components/optional/_form_input_range.scss
@@ -1,2 +1,0 @@
-.form__input-range {
-}

--- a/assets/stylesheets/components/optional/_tab_selector.scss
+++ b/assets/stylesheets/components/optional/_tab_selector.scss
@@ -1,6 +1,3 @@
-// Tab selector, stays as tabs at all viewport widths
-//
-// Styleguide Tab selector
 .tab-selector__triggers-outer {
   position: relative;
 }
@@ -76,9 +73,6 @@
   @extend .visually-hidden;
 }
 
-// Tab selector, collapsing to dropdown below medium breakpoint
-//
-// Styleguide Tab selector collapsable
 .tab-selector--collapsable {
   &.is-collapsed {
 

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.7.2'
+  VERSION = '5.7.3'
 end


### PR DESCRIPTION
- the comments in the Sass files for these components
  drive the documentation created by KSS
- the dough comments appear to override comments
  which are added to the dough theme on the MAS website
- by removing these comments we allow the dough theme
  in the frontend MAS website to control what is output
  in the styleguide and not dough