### PR TITLE
Add ConfirmableForm component

### DIFF
--- a/assets/js/components/ConfirmableForm.js
+++ b/assets/js/components/ConfirmableForm.js
@@ -1,0 +1,89 @@
+/**
+ * # Confirmable form
+ *
+ * A form that pops up a confirm dialogue before submission.
+ * If the user says no, submission is blocked.
+ * Otherwise, it submits as normal.
+ *
+ * You can set the confirmation message by setting the
+ * attribute `data-dough-confirmation-message`.
+ *
+ * @module ConfirmableForm
+ * @returns {class} ConfirmableForm
+ */
+
+define(['jquery', 'DoughBaseComponent'],
+       function($, DoughBaseComponent) {
+  'use strict';
+
+  var ConfirmableFormProto,
+      defaultConfig = {
+        messageAttribute: 'data-dough-confirmation-message'
+      };
+
+  /**
+   * @constructor
+   * @extends {DoughBaseComponent}
+   * @param {HTMLElement} $el    Element with dough-component on it
+   * @param {Object}      config Hash of config options
+   */
+  function ConfirmableForm($el, config) {
+    ConfirmableForm.baseConstructor.call(this, $el, config, defaultConfig);
+  }
+
+  /**
+   * Inherit from base module, for shared methods and interface
+   */
+  DoughBaseComponent.extend(ConfirmableForm);
+  ConfirmableForm.componentName = 'ConfirmableForm';
+  ConfirmableFormProto = ConfirmableForm.prototype;
+
+  /**
+   * Init function
+   *
+   * Set up listeners and accept promise
+   *
+   * @param {Object} initialised Promise passed from eventsWithPromises (RSVP Promise).
+   * @returns {MultiTableFilter}
+   */
+  ConfirmableFormProto.init = function(initialised) {
+    this.message = this.$el.attr(this.config.messageAttribute);
+    this.bindListenerToForm();
+    this._initialisedSuccess(initialised);
+    return this;
+  };
+
+  /**
+   * bindListenerToForm
+   *
+   * Binds `submit` listener to form tag that pops
+   * up a confirm dialogue.
+   */
+  ConfirmableFormProto.bindListenerToForm = function() {
+    var self = this,
+        $form = self.getFormFromComponent();
+
+    $form.submit(function(e) {
+      if(window.confirm(self.message)) {
+        return true;
+      } else {
+        $.event.fix(e).preventDefault();
+      }
+    });
+  };
+
+  /**
+   * getFormFromComponent
+   *
+   * If the component itself is a form, use that.
+   * Otherwise, use the nearest parent form.
+   *
+   * @returns {HTMLElement} Form element to be used.
+   */
+  ConfirmableFormProto.getFormFromComponent = function() {
+    if(this.$el.is('form')) { return this.$el; }
+    return this.$el.parents('form').first();
+  };
+
+  return ConfirmableForm;
+});

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.7.4'
+  VERSION = '5.8.0'
 end

--- a/spec/js/fixtures/ConfirmableForm.html
+++ b/spec/js/fixtures/ConfirmableForm.html
@@ -1,0 +1,5 @@
+<div>
+  <form action="#" data-dough-confirmation-message="The message">
+    <input type="submit" value="Submit">
+  </form>
+</div>

--- a/spec/js/fixtures/ConfirmableFormOnInput.html
+++ b/spec/js/fixtures/ConfirmableFormOnInput.html
@@ -1,0 +1,5 @@
+<div>
+  <form action="#">
+    <input type="submit" value="Submit" data-dough-confirmation-message="The message">
+  </form>
+</div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -28,6 +28,7 @@ require.config({
     mediaQueries: 'assets/js/lib/mediaQueries',
     componentLoader: 'assets/js/lib/componentLoader',
     Collapsable: 'assets/js/components/Collapsable',
+    ConfirmableForm: 'assets/js/components/ConfirmableForm',
     TabSelector: 'assets/js/components/TabSelector',
     RangeInput: 'assets/js/components/RangeInput',
     FieldHelpText: 'assets/js/components/FieldHelpText',

--- a/spec/js/tests/ConfirmableForm_spec.js
+++ b/spec/js/tests/ConfirmableForm_spec.js
@@ -52,7 +52,7 @@ describe('confirmation form', function () {
       var self = this;
 
       requirejs(['jquery', 'ConfirmableForm'], function ($, ConfirmableForm) {
-        self.$html = $(window.__html__['spec/javascripts/fixtures/ConfirmableFormOnInput.html']).appendTo('body');
+        self.$html = $(window.__html__['spec/js/fixtures/ConfirmableFormOnInput.html']).appendTo('body');
         self.$input = self.$html.find('input');
         self.$form = self.$html.find('form');
         self.ConfirmableForm = new ConfirmableForm(self.$input).init();
@@ -70,7 +70,7 @@ describe('confirmation form', function () {
       var self = this;
 
       requirejs(['jquery', 'ConfirmableForm'], function ($, ConfirmableForm) {
-        self.$html = $(window.__html__['spec/javascripts/fixtures/ConfirmableForm.html']).appendTo('body');
+        self.$html = $(window.__html__['spec/js/fixtures/ConfirmableForm.html']).appendTo('body');
         self.$input = self.$html.find('input');
         self.$form = self.$html.find('form');
         self.ConfirmableForm = new ConfirmableForm(self.$form).init();

--- a/spec/js/tests/ConfirmableForm_spec.js
+++ b/spec/js/tests/ConfirmableForm_spec.js
@@ -1,0 +1,85 @@
+describe('confirmation form', function () {
+  'use strict';
+  var sandbox;
+
+  var itBehavesLikeAConfirmableForm = function() {
+    afterEach(function() {
+      this.$html.remove();
+      sandbox.restore();
+    });
+
+    // We want to know whether the form submission has been
+    // blocked. So we listen for submit, and then check
+    // whether default has been prevented. This flag is
+    // assessed later on.
+    // Note that we also need to block submission ourselves
+    // so Karma doesn't complain.
+    beforeEach(function() {
+      var self = this;
+      self.$form.submit(function(e) {
+        self.defaultPrevented = e.isDefaultPrevented();
+        e.preventDefault();
+      });
+    });
+
+    it('exists', function() {
+      expect(this.$input).to.exist;
+    });
+
+    it('lets submission continue if the user confirms', function() {
+      sandbox.stub(window, 'confirm').returns(true);
+      this.$input.click();
+      expect(this.defaultPrevented).to.eq(false);
+    });
+
+    it('blocks submission if the user does not confirm', function() {
+      var confirm = sandbox.stub(window, 'confirm').returns(false);
+      this.$input.click();
+      expect(this.defaultPrevented).to.eq(true);
+    });
+
+    it('blocks submission if the user does not confirm', function() {
+      var calledWith,
+          stubFn = function(arg) { calledWith = arg; return true; },
+          confirm = sandbox.stub(window, 'confirm', stubFn);
+      this.$input.click();
+      expect(calledWith).to.eq('The message');
+    });
+  };
+
+  describe('on an input field', function() {
+    beforeEach(function (done) {
+      var self = this;
+
+      requirejs(['jquery', 'ConfirmableForm'], function ($, ConfirmableForm) {
+        self.$html = $(window.__html__['spec/javascripts/fixtures/ConfirmableFormOnInput.html']).appendTo('body');
+        self.$input = self.$html.find('input');
+        self.$form = self.$html.find('form');
+        self.ConfirmableForm = new ConfirmableForm(self.$input).init();
+        sandbox = sinon.sandbox.create();
+
+        done();
+      }, done);
+    });
+
+    itBehavesLikeAConfirmableForm();
+  });
+
+  describe('on a form', function() {
+    beforeEach(function (done) {
+      var self = this;
+
+      requirejs(['jquery', 'ConfirmableForm'], function ($, ConfirmableForm) {
+        self.$html = $(window.__html__['spec/javascripts/fixtures/ConfirmableForm.html']).appendTo('body');
+        self.$input = self.$html.find('input');
+        self.$form = self.$html.find('form');
+        self.ConfirmableForm = new ConfirmableForm(self.$form).init();
+        sandbox = sinon.sandbox.create();
+
+        done();
+      }, done);
+    });
+
+    itBehavesLikeAConfirmableForm();
+  });
+});


### PR DESCRIPTION
This adds the ConfirmableForm component originally created within the RAD codebase (https://github.com/moneyadviceservice/rad/commit/d2d4f3b6739e51346b6ac50fdb082229c68c0624?diff=unified).

We've had to port the functionality across to https://github.com/moneyadviceservice/webfeeds to add a piece of functionality. This PR would allow us to remove the duplication from both both RAD and Webfeeds.