### PR TITLE
add single whitespaces after if keyword

### DIFF
--- a/assets/js/components/ConfirmableForm.js
+++ b/assets/js/components/ConfirmableForm.js
@@ -64,7 +64,7 @@ define(['jquery', 'DoughBaseComponent'],
         $form = self.getFormFromComponent();
 
     $form.submit(function(e) {
-      if(window.confirm(self.message)) {
+      if (window.confirm(self.message)) {
         return true;
       } else {
         $.event.fix(e).preventDefault();
@@ -81,7 +81,7 @@ define(['jquery', 'DoughBaseComponent'],
    * @returns {HTMLElement} Form element to be used.
    */
   ConfirmableFormProto.getFormFromComponent = function() {
-    if(this.$el.is('form')) { return this.$el; }
+    if (this.$el.is('form')) { return this.$el; }
     return this.$el.parents('form').first();
   };
 


### PR DESCRIPTION
I had ran the `jshint` command line tool, but missed there was an additional `jscs` command line tool for linting. Travis builds didn't raise an error, but the GO server failed to build the gem because of two errors:

```
One space required after "if" keyword at assets/js/components/ConfirmableForm.js :
    65 |
    66 |    $form.submit(function(e) {
    67 |      if(window.confirm(self.message)) {
----------------^
    68 |        return true;
    69 |      } else {

One space required after "if" keyword at assets/js/components/ConfirmableForm.js :
    82 |   */
    83 |  ConfirmableFormProto.getFormFromComponent = function() {
    84 |    if(this.$el.is('form')) { return this.$el; }
--------------^
    85 |    return this.$el.parents('form').first();
    86 |  };
```

