### PR TITLE
Use jQuery 1.11.* to match frontend

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "normalize-css": "~3.0.0",
     "eventsWithPromises": "https://github.com/moneyadviceservice/eventsWithPromises.git#master",
     "requirejs": "latest",
-    "jquery": "latest",
+    "jquery": "1.11.*",
     "jqueryThrottleDebounce": "https://github.com/cowboy/jquery-throttle-debounce.git"
   },
   "devDependencies": {


### PR DESCRIPTION
Build is failing to due to version mismatches on jQuery, probably safer to specify the same version string as frontend and the engines use here.