### PR TITLE
Add deps on mocha and requirejs (and alpha sort deps list)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "karma-phantomjs-launcher": "~0.1",
     "karma-requirejs": "^0.2.1",
     "karma-sinon": "^1.0.3",
-    "mocha": "2.3.4",
-    "requirejs": "2.1.22",
+    "mocha": "^2.3.4",
+    "requirejs": "^2.1.22",
     "sinon": "~1.9.0",
     "sinon-chai": "^2.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "grunt": "~0.4.4",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-dox": "~0.5.0",
+    "gulp": "^3.8.11",
+    "gulp-gh-pages": "^0.5.1",
+    "gulp-jsdoc": "^0.1.4",
+    "jaguarjs-jsdoc": "0.0.1",
     "jscs": "^1.5.4",
     "jshint": "^2.5.5",
     "karma": "^0.12.2",
-    "karma-osx-reporter": "*",
     "karma-chai": "^0.1.0",
     "karma-chai-jquery": "^1.0.0",
     "karma-chrome-launcher": "^0.1.2",
@@ -37,14 +40,13 @@
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^0.1.3",
+    "karma-osx-reporter": "*",
     "karma-phantomjs-launcher": "~0.1",
     "karma-requirejs": "^0.2.1",
     "karma-sinon": "^1.0.3",
+    "mocha": "2.3.4",
+    "requirejs": "2.1.22",
     "sinon": "~1.9.0",
-    "sinon-chai": "^2.5.0",
-    "gulp": "^3.8.11",
-    "gulp-jsdoc": "^0.1.4",
-    "jaguarjs-jsdoc": "0.0.1",
-    "gulp-gh-pages": "^0.5.1"
+    "sinon-chai": "^2.5.0"
   }
 }


### PR DESCRIPTION
# What?


This change adds 

```diff
+    "mocha": "^2.3.4",
+    "requirejs": "^2.1.22",
```

as local development dependencies.

(Also npm install automatically alpha sorted the list)

# Why?

In a fresh install, `npm install` outputs:

```sh
$ npm install
npm WARN karma-mocha@0.1.10 requires a peer of mocha@* but none was installed.
npm WARN karma-requirejs@0.2.3 requires a peer of requirejs@~2.1 but none was installed.
```

And sure enough the tests fail without these packages.

# Should we?

Does anyone know any good reason why this was necessary and why we shouldn't do this?

It may be that in the past somewhere in the dependency tree these packages were automatically being included (e.g. via karma-mocha and karma-requirejs) but they aren't now.