### PR TITLE
Validate checkboxes

### DIFF
--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -277,7 +277,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
           inlineErrorID = this._getInlineErrorID($field.attr('name'));
 
       $field.removeAttr('aria-invalid');
-      $field.attr('aria-describedby', existingDescribedBy.replace(inlineErrorID, ''));
+      $field.attr('aria-describedby', existingDescribedBy.replace(new RegExp(inlineErrorID, 'g'), ''));
     }, this));
 
     return this;
@@ -375,6 +375,12 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     return fieldGroupValidity;
   };
 
+  /**
+   * Returns true if the given field is a radio button or a checkbox
+   *
+   * @param  {jQuery} $field   the field being checked
+   * @return {boolean}         whether or not the given field is a radio button or checkbox
+   */
   Validation.prototype._isCheckable = function($field) {
     return $field.is('[type="radio"]') || $field.is('[type="checkbox"]');
   };
@@ -384,7 +390,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    *
    * @param  {jQuery} $field   the field being checked
    * @param  {String} value    the field value
-   * @param  {String} required Validation parameters
    * @return {Object}          Validity object
    */
   Validation.prototype._validateRequired = function($field, value) {
@@ -543,7 +548,12 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @return {void}
    */
   Validation.prototype._handleBlurEvent = function(e) {
-    this.checkfieldGroupValidity($(e.target));
+    var $field = $(e.target),
+        isCheckbox = $field.is('[type="checkbox"]');
+
+    if (!isCheckbox) {
+      this.checkfieldGroupValidity($field);
+    }
   };
 
   /**

--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -375,6 +375,9 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
     return fieldGroupValidity;
   };
 
+  Validation.prototype._isCheckable = function($field) {
+    return $field.is('[type="radio"]') || $field.is('[type="checkbox"]');
+  };
 
   /**
    * Basic required field validator, for non-empty
@@ -387,7 +390,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   Validation.prototype._validateRequired = function($field, value) {
     var validity = { name: 'required' };
 
-    if ($field.is('[type="radio"]') && !$field.prop('checked')) {
+    if (this._isCheckable($field) && !$field.prop('checked')) {
       validity.isEmpty = true;
     }
     else {

--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -116,7 +116,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @return {Validation} Class instance
    */
   Validation.prototype.refreshInlineErrors = function() {
-    if (!this.config.showInlineValidation) return this;
+    if (!this.config.showInlineValidation) { return this; }
 
     this.$el.find('.form__row').each($.proxy(function(i, o) {
       var $formRow = $(o),
@@ -159,7 +159,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @return {Validation} Class instance
    */
   Validation.prototype.refreshValidationSummary = function() {
-    if (!this.config.showValidationSummary) return this;
+    if (!this.config.showValidationSummary) { return this; }
 
     var fieldName,
         summaryHTML = '';
@@ -248,7 +248,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @return {Validation}  Class instance
    */
   Validation.prototype._addAccessibility = function($fieldGroup) {
-    if (!this.config.showInlineValidation) return this;
+    if (!this.config.showInlineValidation) { return this; }
 
     $fieldGroup.each($.proxy(function(i, field) {
       var $field = $(field),
@@ -289,7 +289,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
    * @return {type} [description]
    */
   Validation.prototype._showValidationSummary = function() {
-    if (!this.config.showValidationSummary) return this;
+    if (!this.config.showValidationSummary) { return this; }
 
     this.$el.find('.' + this.config.validationSummaryClass).removeClass(this.config.validationSummaryHiddenClass);
     return this;

--- a/spec/js/fixtures/Validation/Checkboxes.html
+++ b/spec/js/fixtures/Validation/Checkboxes.html
@@ -1,0 +1,22 @@
+<div>
+  <form data-dough-component="Validation" class="form" action="/test" novalidate>
+    <div class="form__row ">
+        <input aria-required="true"
+               data-dough-validation-empty="You must pick at least one."
+               id="input1"
+               name="current_answer"
+               required="required"
+               type="checkbox"
+               value="first_input">
+        <input aria-required="true"
+               data-dough-bind-checked="current_answer"
+               data-dough-validation-empty="You must pick at least one."
+               id="input2"
+               name="current_answer"
+               required="required"
+               type="checkbox"
+               value="second_input">
+    </div>
+    <input type="submit" id="submit">
+  </form>
+</div>

--- a/spec/js/fixtures/Validation/RadioButtons.html
+++ b/spec/js/fixtures/Validation/RadioButtons.html
@@ -2,17 +2,18 @@
   <form data-dough-component="Validation" class="form" action="/test" novalidate>
     <div class="form__row ">
         <input
-              id="input1"
               aria-required="true"
-              class="input--radio input--radio-first"
               data-dough-validation-empty="You must enter your gender to continue."
-              name="gender" required="required" type="radio" value="female">
+              name="gender"
+              required="required"
+              id="input1" type="radio" value="female">
         <input
-              id="input2"
               aria-required="true"
-              class="input--radio" data-dough-bind-checked="gender"
+              data-dough-bind-checked="gender"
               data-dough-validation-empty="You must enter your gender to continue."
-              name="gender" required="required" type="radio" value="male">
+              name="gender"
+              required="required"
+              id="input2" type="radio" value="male">
     </div>
     <input type="submit" id="submit">
   </form>

--- a/spec/js/tests/Validation_spec.js
+++ b/spec/js/tests/Validation_spec.js
@@ -604,6 +604,196 @@ describe('Validation', function() {
     });
   });
 
+  // Checkboxes
+  describe('Required Checkboxes', function() {
+    beforeEach(function(done) {
+      var self = this;
+      requirejs(
+          ['jquery', 'Validation'],
+          function($, Validation) {
+            self.$html = $(window.__html__['spec/js/fixtures/Validation/Checkboxes.html']).appendTo('body');
+            self.component = self.$html.find('[data-dough-component="Validation"]');
+            self.Validation = Validation;
+            done();
+          }, done);
+    });
+
+    afterEach(function() {
+      this.$html.remove();
+    });
+
+    describe('when inline validation is enabled', function() {
+      it('shows the correct inline error if all checkboxes are left empty on submit', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: true}).init(),
+            $input = validation.$el.find('#input1'),
+            errorLookingFor = $input.attr(validation.config.attributeEmpty);
+
+        validation.$el.submit();
+
+        expect(validation.$el.find('.' + validation.config.inlineErrorClass + ':contains("' + errorLookingFor + '")').length).to.equal(1);
+      });
+
+      it('adds the is-errored class to the parent form__row', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: true}).init(),
+            $input = validation.$el.find('#input1');
+
+        validation.$el.submit();
+
+        expect($input.parents('.form__row')).to.have.class(validation.config.rowInvalidClass);
+      });
+
+      it('adds the aria-invalid attribute to both inputs', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: true}).init(),
+            $input1 = validation.$el.find('#input1'),
+            $input2 = validation.$el.find('#input2');
+
+        validation.$el.submit();
+
+        expect($input1).to.have.attr('aria-invalid', 'true');
+        expect($input2).to.have.attr('aria-invalid', 'true');
+      });
+
+      it('references the inline error with the aria-describedby attribute on both inputs when invalid', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: true}).init(),
+            $input1 = validation.$el.find('#input1'),
+            $input2 = validation.$el.find('#input2');
+
+        validation.$el.submit();
+
+        expect($input1.attr('aria-describedby').indexOf(validation._getInlineErrorID($input1.attr('name')))).not.to.equal(-1);
+        expect($input2.attr('aria-describedby').indexOf(validation._getInlineErrorID($input2.attr('name')))).not.to.equal(-1);
+      });
+
+      // it('removes references to the inline error from aria-describedby when valid on both inputs', function() {
+      //   var validation = new this.Validation(this.component, {showInlineValidation: true}).init(),
+      //       $input1 = validation.$el.find('#input1'),
+      //       $input2 = validation.$el.find('#input2');
+
+      //   this.component.trigger('submit');
+      //   $input1.prop('checked', true).change();
+
+      //   expect($input1.attr('aria-describedby').indexOf(validation._getInlineErrorID($input1.attr('name')))).to.equal(-1);
+      //   expect($input2.attr('aria-describedby').indexOf(validation._getInlineErrorID($input2.attr('name')))).to.equal(-1);
+      // });
+
+      it('removes all relevant errors and error states if value corrected as the checkbox is selected', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: true}).init(),
+            $input = validation.$el.find('#input1'),
+            errorLookingFor = $input.attr(validation.config.attributeEmpty),
+            $validationSummaryList = validation.$el.find('[' + validation.config.validationSummaryListAttribute + ']'),
+            $inlineError = $input.parent('.form__row').find('.' + validation.config.inlineErrorClass);
+
+        validation.$el.submit();
+        $input.prop('checked', true).change();
+
+        expect($input.parents('.form__row')).not.to.have.class(validation.config.rowInvalidClass);
+        expect($validationSummaryList.filter(':contains("' + errorLookingFor + '")').length).to.equal(0);
+        expect($inlineError.filter(':contains("' + errorLookingFor + '")').length).to.equal(0);
+      });
+    });
+
+    describe('when inline validation is disabled', function() {
+      it('does not show an inline error if all checkboxes are left empty on submit', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: false}).init(),
+            $input = validation.$el.find('#input1'),
+            errorLookingFor = $input.attr(validation.config.attributeEmpty);
+
+        validation.$el.submit();
+
+        expect(validation.$el.find('.' + validation.config.inlineErrorClass + ':contains("' + errorLookingFor + '")').length).to.equal(0);
+      });
+
+      it('does not add the is-errored class to the parent form__row', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: false}).init(),
+            $input = validation.$el.find('#input1');
+
+        validation.$el.submit();
+
+        expect($input.parents('.form__row')).not.to.have.class(validation.config.rowInvalidClass);
+      });
+
+      it('does not add the aria-invalid attribute to both inputs when submitted', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: false}).init(),
+            $input1 = validation.$el.find('#input1'),
+            $input2 = validation.$el.find('#input2');
+
+        validation.$el.submit();
+
+        expect($input1).not.to.have.attr('aria-invalid', 'true');
+        expect($input2).not.to.have.attr('aria-invalid', 'true');
+      });
+
+      it('does not reference the inline error with the aria-describedby attribute on both inputs when invalid', function() {
+        var validation = new this.Validation(this.component, {showInlineValidation: false}).init(),
+            $input1 = validation.$el.find('#input1'),
+            $input2 = validation.$el.find('#input2');
+
+        validation.$el.submit();
+
+        expect($input1.attr('aria-describedby')).not.to.exist;
+        expect($input2.attr('aria-describedby')).not.to.exist;
+      });
+    });
+
+    describe('when the validation summary is to be shown', function() {
+      it('shows the validation summary if left empty on submit', function() {
+        var validation = new this.Validation(this.component, {showValidationSummary: true}).init(),
+            $validationSummary = validation.$el.find('.' + validation.config.validationSummaryClass);
+
+        validation.$el.submit();
+
+        expect($validationSummary).to.not.have.class(validation.config.validationSummaryHiddenClass);
+      });
+
+      it('does not show the validation summary if the form has not been submitted', function() {
+        var validation = new this.Validation(this.component, {showValidationSummary: true}).init(),
+            $validationSummary = validation.$el.find('.' + validation.config.validationSummaryClass);
+
+        expect($validationSummary).to.have.class(validation.config.validationSummaryHiddenClass);
+      });
+
+      it('adds the error (only once) to the validation summary list if left empty on submit', function() {
+        var validation = new this.Validation(this.component, {showValidationSummary: true}).init(),
+            $input = validation.$el.find('#input1'),
+            errorLookingFor = $input.attr(validation.config.attributeEmpty),
+            $validationSummaryList = validation.$el.find('[' + validation.config.validationSummaryListAttribute + ']');
+
+        validation.$el.submit();
+
+        expect($validationSummaryList.find('li:contains("' + errorLookingFor + '")').length).to.equal(1);
+      });
+    });
+
+    describe('when the validation summary is not to be shown', function() {
+      it('has not created the validation summary', function() {
+        var validation = new this.Validation(this.component, {showValidationSummary: false}).init(),
+            $validationSummary = validation.$el.find('.' + validation.config.validationSummaryClass);
+
+        expect($validationSummary.length).to.equal(0);
+      });
+
+      it('does not create the validation summary on submit', function() {
+        var validation = new this.Validation(this.component, {showValidationSummary: false}).init(),
+            $validationSummary = validation.$el.find('.' + validation.config.validationSummaryClass);
+
+        validation.$el.submit();
+
+        expect($validationSummary.length).to.equal(0);
+      });
+    });
+
+    it('allows the form to submit if the value is filled in', function() {
+      var validation = new this.Validation(this.component).init(),
+          $input = validation.$el.find('#input1'),
+          $validationSummaryList = validation.$el.find('[' + validation.config.validationSummaryListAttribute + ']');
+
+      $input.prop('checked', true).change();
+      validation.$el.submit();
+
+      expect($validationSummaryList.find('li').length).to.equal(0);
+    });
+  });
+
 
 
   // Minimum length check


### PR DESCRIPTION
This PR brings client-side validation to checkboxes as well as radio buttons and text fields. As long as all of the checkboxes in the group have the same name and are within the same `form__row`, you can validate that at least one checkbox has been checked.

In order to prevent surprising UI behaviour I also disabled blur events for checkboxes because, unlike radio buttons, you can check and then uncheck a checkbox. This was leading to situations where, if you checked a checkbox and then unchecked it again, when you went to check on the next checkbox in the group it would display an error.