### PR TITLE
[DEV APPROVED] Add a Print component

### DIFF
--- a/assets/js/components/Print.js
+++ b/assets/js/components/Print.js
@@ -1,0 +1,42 @@
+/**
+ * Attaches a click handler to $el which when triggered shows the print dialog.
+ *
+ * @param  {object} $ (jQuery)
+ * @param  {function} DoughBaseComponent
+ * @module Print
+ * @returns {class} Print
+ */
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+  'use strict';
+
+  var Print,
+      defaultConfig = {};
+
+  /**
+   * @constructor
+   * @extends {DoughBaseComponent}
+   * @returns {Print}
+   */
+
+  Print = function($el, config) {
+    Print.baseConstructor.call(this, $el, config, defaultConfig);
+  };
+
+  DoughBaseComponent.extend(Print);
+
+  Print.componentName = 'Print';
+
+  /**
+   * Initialise component
+   * @param {Object} initialised Promise passed from eventsWithPromises (RSVP Promise).
+   */
+  Print.prototype.init = function(initialised) {
+    this.$el.click(function() {
+      window.print();
+    });
+
+    this._initialisedSuccess(initialised);
+  };
+
+  return Print;
+});

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.10.1'
+  VERSION = '5.11.0'
 end

--- a/spec/js/fixtures/Print.html
+++ b/spec/js/fixtures/Print.html
@@ -1,0 +1,3 @@
+<div>
+  <button data-dough-component="Print">Print!</button>
+</div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -24,6 +24,7 @@ require.config({
     componentLoader: 'assets/js/lib/componentLoader',
     Collapsable: 'assets/js/components/Collapsable',
     ConfirmableForm: 'assets/js/components/ConfirmableForm',
+    Print: 'assets/js/components/Print',
     TabSelector: 'assets/js/components/TabSelector',
     RangeInput: 'assets/js/components/RangeInput',
     FieldHelpText: 'assets/js/components/FieldHelpText',

--- a/spec/js/tests/Print_spec.js
+++ b/spec/js/tests/Print_spec.js
@@ -1,0 +1,31 @@
+describe('Print', function () {
+  'use strict';
+  var ctx = {};
+
+  beforeEach(function(done) {
+    requirejs(['jquery', 'Print'], function ($, Print) {
+      ctx.$html = $(window.__html__['spec/js/fixtures/Print.html']).appendTo('body');
+      ctx.$component = ctx.$html.find('[data-dough-component="Print"]');
+      ctx.describedClass = Print;
+      ctx.subject = new ctx.describedClass(ctx.$component, {});
+      ctx.subject.init();
+
+      ctx.windowPrintStub = sinon.stub(window, 'print');
+
+      done();
+    }, done);
+  });
+
+  afterEach(function() {
+    ctx.windowPrintStub.restore();
+    ctx.$html.remove();
+  });
+
+  describe('when the target element is clicked', function() {
+    it('triggers the browser to show the print dialog', function() {
+      expect(ctx.windowPrintStub.called).not.to.eq(true);
+      ctx.$component.click();
+      expect(ctx.windowPrintStub.called).to.eq(true);
+    });
+  });
+});


### PR DESCRIPTION
# What?

Adds a very very simple Dough component that lets you easily create a "Print" button on the page, which when pressed opens the browser's print dialog.

# How to use it?

Get it loaded into your project in the usual MAS way using RequireJS, then tag your button like so:

```html
<button data-dough-component="Print">
  Print
</button>
```