### PR TITLE
[DEV APPROVED] Adding new config parameter for RangeInput

### DIFF
--- a/assets/js/components/RangeInput.js
+++ b/assets/js/components/RangeInput.js
@@ -14,7 +14,7 @@ define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
 
   var defaultConfig = {
         keepSynced: true,
-        ignoreAtts: ""
+        ignoreAtts: ''
       },
       RangeInput;
 

--- a/assets/js/components/RangeInput.js
+++ b/assets/js/components/RangeInput.js
@@ -7,12 +7,14 @@
  * @module RangeInput
  * @returns {class} RangeInput
  */
+
 define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
     function($, DoughBaseComponent, featureDetect, eventsWithPromises) {
   'use strict';
 
   var defaultConfig = {
-        keepSynced: true
+        keepSynced: true,
+        ignoreAtts: ""
       },
       RangeInput;
 
@@ -57,7 +59,7 @@ define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
           'type': 'range',
           'aria-role': 'slider'
         })
-        .removeAttr('name data-dough-range-input')
+        .removeAttr('name data-dough-range-input ' + this.config.ignoreAtts)
         .on('input change', function() { // recapture focus on slider for iOS w/ Voiceover
           $(this).focus();
         })
@@ -82,6 +84,7 @@ define(['jquery', 'DoughBaseComponent', 'featureDetect', 'eventsWithPromises'],
     });
     $rangeInput.on('change input', function() {
       $textInput.val($rangeInput.val());
+      $textInput.change();
     });
   };
 

--- a/spec/js/fixtures/RangeInput.html
+++ b/spec/js/fixtures/RangeInput.html
@@ -1,4 +1,4 @@
 <div>
   <label for="my_input">label</label>
-  <input id="my_input" data-dough-range-input type="text" min="1000" max="5000" value="1500"/>
+  <input id="my_input" data-dough-range-input type="text" min="1000" max="5000" value="1500" data-attribute="foo"/>
 </div>

--- a/spec/js/tests/RangeInput_spec.js
+++ b/spec/js/tests/RangeInput_spec.js
@@ -62,9 +62,24 @@ describe('Range input', function() {
         value: '3000'
       });
     });
-
   });
 
+  describe('Range inputs supported, passing an HTML attribute to ignore', function() {
+
+    beforeEach(function() {
+      this.featureDetect.inputtypes.range = true;
+      this.rangeInput = new this.RangeInput(this.$html, {
+        ignoreAtts: 'data-attribute'
+      });
+      this.$inputText = this.$html.find('[data-dough-range-input]');
+      this.$inputSlider = this.$html.find('.form__input-range');
+    });
+
+    it('Does not clone an attribute passed in the ignoreAtts parameter', function() {
+      expect(this.$inputText.attr('data-attribute')).to.equal('foo');
+      expect(this.$inputSlider.attr('data-attribute')).to.be.undefined;
+    });
+  });
 
   describe('Range inputs supported but don\'t keep inputs in sync', function() {
 


### PR DESCRIPTION
## Context:
The RangeInput (slider) component in Dough takes an input field, checks for browser support of `input type="range"` and if supported, creates a range input by cloning the original input and changing the type of the clone to 'range'.

## Detail:
This PR changes two things in the RangeInput component in Dough. 

1. Adds an optional config parameter for any HTML Attributes that should be ignored when cloning the original input.
2. When the range input is updated, triggers a 'change' event on the text input - this may be needed if a JS data-binding framework is used which is watching for changes to the field.