### PR TITLE
[DEV APPROVED] Make it possible to use the tab_selector style without JavaScript

### DIFF
--- a/assets/stylesheets/components/optional/_tab_selector.scss
+++ b/assets/stylesheets/components/optional/_tab_selector.scss
@@ -17,7 +17,17 @@
   .js & {
     display: inline-block;
   }
-  [data-dough-tab-selector-initialised="yes"] & {
+
+  /*
+   * When tab selector is being used within a single page the tabs are not
+   * visible until the data-dough-tab-selector-initialised marker attribute
+   * has been added to the containing element.
+   *
+   * To use the tabs without JavaScript when each tab actually links to a
+   * separate page add the tab-selector--without-js modifier class to the
+   * containing element.
+   */
+  [data-dough-tab-selector-initialised="yes"] &, .tab-selector--without-js & {
     visibility: visible;
     &.is-active {
       display: inline-block;

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.11.0'
+  VERSION = '5.12.0'
 end


### PR DESCRIPTION
# What?

Provides a way to use the MAS tab styles to link to separate pages.

# Why?

Currently the tab_selector styles are designed to add tabs to switch between content blocks within a single page. But for RAD we wanted to reuse the house style to switch between separate pages.

To make this possible we need a way to override the default behaviour that hides the tabs until the related JavaScript component has initialised. Because for our case we don't need the JS component.

E.g. if you just define a set of tabs without the JS component:

```html
<div class="tab-selector">
  <div class="tab-selector__triggers-outer">
    <div class="tab-selector__triggers-inner">
      <div class="tab-selector__trigger-container">
        <a class="tab-selector__trigger is-active" href="firm_details.html">Firm details</a>
      </div>
      <div class="tab-selector__trigger-container">
        <a class="tab-selector__trigger is-inactive" href="advisers.html">Advisers (3)</a>
      </div>
      <div class="tab-selector__trigger-container">
        <a class="tab-selector__trigger is-inactive" href="offices.html">Offices (1)</a>
      </div>
    </div>
  </div>
</div>
```

you get just the green border and no tabs:

![screen shot 2016-02-25 at 11 09 43](https://cloud.githubusercontent.com/assets/306583/13318042/77469c8c-dbb0-11e5-89b2-a2d5478c3b6d.png)

Now when you add the new marker we introduced:

```html
<div class="tab-selector tab-selector--without-js">
```

It makes them appear:

![screen shot 2016-02-25 at 11 09 56](https://cloud.githubusercontent.com/assets/306583/13318089/ad6f95e8-dbb0-11e5-8bc0-dbadfd97d30a.png)