### PR TITLE
[DEV APPROVED] Dough mediaQueries bug fixes x2 + 1x feature

### DIFF
--- a/assets/js/lib/mediaQueries.js
+++ b/assets/js/lib/mediaQueries.js
@@ -29,7 +29,7 @@ define(['jquery', 'eventsWithPromises', 'featureDetect', 'jqueryThrottleDebounce
    */
   function getSize() {
     return featureDetect.mediaQueries ?
-      window.getComputedStyle(testElement[0], ':after').getPropertyValue('content') : 'mq-l';
+      window.getComputedStyle(testElement[0], ':after').getPropertyValue('content').replace(/"/g, '') : 'mq-l';
   }
 
   /**

--- a/assets/js/lib/mediaQueries.js
+++ b/assets/js/lib/mediaQueries.js
@@ -18,7 +18,8 @@ define(['jquery', 'eventsWithPromises', 'featureDetect', 'jqueryThrottleDebounce
   'use strict';
 
   var current = false,
-      testElement = $('<div class="js-mediaquery-test" />');
+      testElement = $('<div class="js-mediaquery-test" />'),
+      $pageElement = $('html');
 
   /**
    * Gets current media query value as set using the
@@ -42,24 +43,41 @@ define(['jquery', 'eventsWithPromises', 'featureDetect', 'jqueryThrottleDebounce
   function checkSize(forceEvent) {
     var newSize = getSize();
     if ((newSize !== current) || forceEvent) {
+      updatePageClass(current, newSize);
+
       current = newSize;
       eventsWithPromises.publish('mediaquery:resize', {
         newSize: newSize // `mq-xs` or `mq-s`, etc
       });
+
     }
+  }
+
+
+  /**
+   *
+   * Removes the current mq- class on the page (html) element and sets the new one.
+   * @function
+   * @param  {String} current mq- className.
+   * @param  {String} new mq- className.
+   */
+  function updatePageClass(currentClassName, newClassName){
+    $pageElement
+      .addClass(newClassName)
+      .removeClass(currentClassName);
   }
 
   /**
    * Initialise module
    * @function
    */
-  function init ($el) {
+  function init ($elem) {
 
     if (!featureDetect.mediaQueries) {
       return;
     }
 
-    $el = $el || $('body');
+    var $el = $elem || $('body');
     if (!$(testElement).closest($el).length) {
       $el.append(testElement);
 


### PR DESCRIPTION
* getSize() function was returning ""mq-s"" instead of "mq-s". I'm stripping the extra double quotes away to allow it's internal atSmallViewport() to work correctly.

* init() function wasn't appending the testElement to the BODY tag correctly because it was writing it's value to a parameter variable.

* Added an updatePageClass() function which writes the current mq- mediaquery value to the HTML tag so we can use these as prefixes in our SCSS to better support mediaQuery aware components.