### PR TITLE
[DEV APPROVED]Karma tests for collapsable mobile using two PhantomJS browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bower.json
 .DS_Store
 docs/js
 .publish/
+.sass-cache/

--- a/assets/stylesheets/_templates/karma_tests.scss
+++ b/assets/stylesheets/_templates/karma_tests.scss
@@ -1,0 +1,4 @@
+$responsive: true;
+
+@import '../lib/variables';
+@import '../lib/mediaqueries';

--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^0.1.3",
     "karma-osx-reporter": "*",
-    "karma-phantomjs-launcher": "~0.1",
+    "karma-phantomjs-launcher": "^1.0.0",
     "karma-requirejs": "^0.2.1",
     "karma-sinon": "^1.0.3",
     "mocha": "^2.3.4",
+    "phantomjs-prebuilt": "^2.1.5",
     "requirejs": "^2.1.22",
     "sinon": "~1.9.0",
     "sinon-chai": "^2.5.0"

--- a/spec/js/fixtures/CollapsableMobile.html
+++ b/spec/js/fixtures/CollapsableMobile.html
@@ -1,0 +1,8 @@
+<div id="fixture">
+  <div class="collapsable-mobile" data-dough-component="CollapsableMobile">
+    <h3 class="collapsable__targets" data-dough-collapsable-trigger="1">Collapsable Title</h3>
+    <div class="collapsable__target" data-dough-collapsable-target="1">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, porro molestiae at voluptatum esse nesciunt quam quaerat dolores, id praesentium.</p>
+    </div>
+  </div>
+</div>

--- a/spec/js/fixtures/stylesheets/lib.css
+++ b/spec/js/fixtures/stylesheets/lib.css
@@ -1,0 +1,17 @@
+.js-mediaquery-test:after {
+  display: none; }
+  @media screen and (min-width: 0) {
+    .js-mediaquery-test:after {
+      content: 'mq-xs'; } }
+  @media screen and (min-width: 30em) {
+    .js-mediaquery-test:after {
+      content: 'mq-s'; } }
+  @media screen and (min-width: 45em) {
+    .js-mediaquery-test:after {
+      content: 'mq-m'; } }
+  @media screen and (min-width: 60em) {
+    .js-mediaquery-test:after {
+      content: 'mq-l'; } }
+  @media screen and (min-width: 75em) {
+    .js-mediaquery-test:after {
+      content: 'mq-xl'; } }

--- a/spec/js/karma.conf.js
+++ b/spec/js/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'spec/js/fixtures/stylesheets/lib.css',
       'spec/js/test-main.js',
       'spec/js/fixtures/*.html',
       'spec/js/fixtures/Validation/*.html',
@@ -70,7 +71,30 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS_mobile', 'PhantomJS_desktop'],
+
+
+    // Custom browser launchers from phantom-karma-launcher for mobile / desktop
+    customLaunchers: {
+      'PhantomJS_desktop': {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: {
+            width: 1200,
+            height: 1000
+          }
+        }
+      },
+      'PhantomJS_mobile': {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: {
+            width: 320,
+            height: 600
+          }
+        }
+      }
+    },
 
 
     // Continuous Integration mode

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -23,6 +23,7 @@ require.config({
     mediaQueries: 'assets/js/lib/mediaQueries',
     componentLoader: 'assets/js/lib/componentLoader',
     Collapsable: 'assets/js/components/Collapsable',
+    CollapsableMobile: 'assets/js/components/CollapsableMobile',
     ConfirmableForm: 'assets/js/components/ConfirmableForm',
     Print: 'assets/js/components/Print',
     TabSelector: 'assets/js/components/TabSelector',

--- a/spec/js/tests/CollapsableMobile_spec.js
+++ b/spec/js/tests/CollapsableMobile_spec.js
@@ -1,0 +1,79 @@
+describe.only('Visibility toggler on Mobile', function() {
+
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    this.$sandbox = $('<div />').appendTo('body');
+
+    requirejs(['componentLoader', 'CollapsableMobile', 'eventsWithPromises'],
+      function(componentLoader, CollapsableMobile, eventsWithPromises) {
+        self.componentLoader = componentLoader;
+        self.CollapsableMobile = CollapsableMobile;
+        self.eventsWithPromises = eventsWithPromises;
+
+        self.beforeEachHook = function(done, fixtureHTML) {
+          this.$sandbox.html(fixtureHTML || $(window.__html__['spec/js/fixtures/CollapsableMobile.html']));
+
+          this.componentLoader.init(this.$sandbox)
+            .then(function() {
+              this.$trigger = this.$sandbox.find('button');
+              this.$target = this.$sandbox.find('[data-dough-collapsable-target]');
+              this.$header = this.$sandbox.find('.collapsable__targets');
+              this.$desktopLabel = this.$sandbox.find('.collapsable-mobile__desktop-label');
+              this.breakPoint = 720;
+              if (document.width < this.breakPoint) {
+                this.isMobile = true;
+              }
+              done();
+            }.bind(this));
+        };
+        done();
+      });
+  });
+
+  afterEach(function() {
+    this.$sandbox.empty();
+  });
+
+  describe('Testing the initialisation', function() {
+    beforeEach(function(done) {
+      this.beforeEachHook.call(this, done);
+    });
+
+    it('copies the desktop heading to outside the button', function() {
+      // Get the immediate element text without any child element text:
+      var mobileButtonText = this.$trigger.clone().children()
+        .remove().end().text();
+      expect(mobileButtonText).to.equal(this.$desktopLabel.text());
+    });
+
+    it('sets the aria-expanded attribute to false', function() {
+      expect(this.$trigger.attr('aria-expanded')).to.equal('false');
+    });
+  });
+
+
+  describe('Testing the toggle function', function() {
+    beforeEach(function(done) {
+      this.beforeEachHook.call(this, done);
+    });
+
+    it('has the active class after being toggled on Mobile', function() {
+      this.$trigger[0].click();
+
+      if (this.isMobile) {
+        expect(this.$target).to.have.class('is-active');
+      } else {
+        expect(this.$target).to.not.have.class('is-active');
+      }
+    });
+
+    it('removes the active class after being toggled twice', function() {
+      this.$trigger[0].click();
+      this.$trigger[0].click();
+      expect(this.$target).to.not.have.class('is-active');
+    });
+  });
+});

--- a/test.sh
+++ b/test.sh
@@ -10,5 +10,7 @@ time bundle exec rspec
 
 export PATH=./node_modules/.bin:$PATH
 
+sass assets/stylesheets/_templates/karma_tests.scss spec/js/fixtures/stylesheets/lib.css
 karma start spec/js/karma.conf.js --single-run
+
 jscs assets/js


### PR DESCRIPTION
Adds tests for the CollapsableMobile.js component that are mobile-specific (or more accurately, small-screen-specific). The way that this PR does is by running the full suite of Karma tests in an alternative browser size.

One of the extra requirements for this was creating a CSS file with our media queries (which gets recompiled as part of the test script), because mediaqueries within Dough JS depend on CSS.