### PR TITLE
[DEV APPROVED] Refactoring Collapsable Mobile, resize event superfluous

### DIFF
--- a/assets/js/components/CollapsableMobile.js
+++ b/assets/js/components/CollapsableMobile.js
@@ -2,9 +2,8 @@ define(['jquery',
     'DoughBaseComponent',
     'Collapsable',
     'featureDetect',
-    'mediaQueries',
-    'eventsWithPromises'],
-  function($, DoughBaseComponent, Collapsable, featureDetect, mediaQueries, eventsWithPromises) {
+    'mediaQueries'],
+  function($, DoughBaseComponent, Collapsable, featureDetect, mediaQueries) {
 
     'use strict';
 
@@ -33,8 +32,6 @@ define(['jquery',
       // Call Super() method
       CollapsableMobile.superclass.init.call(this, initialised);
 
-      eventsWithPromises.subscribe('mediaquery:resize', $.proxy(this._mediaQueryResizeHandler, this));
-
       // Copy the desktop specific heading to outside of the button.
       label = this.$triggers[0].childNodes[1].wholeText;
       this.$triggers.after('<span class="collapsable-mobile__desktop-label">' + label + '</span>');
@@ -46,7 +43,7 @@ define(['jquery',
       // Override toggle()
 
       // Only call it's super method if on Mobile.
-      if (this._isMobile()) {
+      if (mediaQueries.atSmallViewport()) {
         CollapsableMobile.superclass.toggle.call(this, forceTo, focusTarget);
       }
       else {
@@ -55,28 +52,6 @@ define(['jquery',
       }
 
       return this;
-    };
-
-    CollapsableMobile.prototype._isMobile = function() {
-
-      return mediaQueries.atSmallViewport();
-
-    };
-
-    CollapsableMobile.prototype._mediaQueryResizeHandler = function() {
-
-      this._openIfNotMobile();
-
-    };
-
-    CollapsableMobile.prototype._openIfNotMobile = function() {
-
-      if (!this._isMobile()) {
-        if (!this.isShown) {
-          CollapsableMobile.superclass.toggle.call(this);
-        }
-      }
-
     };
 
     return CollapsableMobile;


### PR DESCRIPTION
Whilst writing the karma tests I found a bit of superfluous functionality in the CollapsableMobile component that we recently added. The component does not need an event handler on window.resize. The component CSS will handle the change in layout when the window is resized to match a new media query.