### PR TITLE
Increasing Dough version no

### DIFF
--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.12.0'
+  VERSION = '5.13.0'
 end


### PR DESCRIPTION
Update to 5.13 as this is a minor functional release.