### PR TITLE
[DEV APPROVED Adding the showlabels and iconPosition atts for Collapsable

### DIFF
--- a/assets/js/components/Collapsable.js
+++ b/assets/js/components/Collapsable.js
@@ -21,6 +21,8 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
         forceTo: false,
         oneGroupOpenOnly: false,
         focusTarget: true,
+        showLabels: false,
+        iconPosition: 'left',
         selectors: {
           trigger: '[data-dough-collapsable-trigger]',
           activeClass: 'is-active',
@@ -69,13 +71,17 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
    */
   Collapsable.prototype._setupAccessibility = function() {
     var id = 'data-dough-collapsable-target-' + this.$target.attr('data-dough-collapsable-target');
-
-    this.$triggers.wrapInner('<button class="unstyled-button" type="button"/>');
+    this.$triggers.addClass('collapsable--icon-' + this.config.iconPosition);
+    this.$triggers.wrapInner('<button class="unstyled-button collapsable-button" type="button"/>');
     this.$triggers.find('button')
+        .addClass('collapsable-button--' +
+          (this.config.showLabels ? 'show' : 'hide') + '-label')
         .prepend('<span data-dough-collapsable-icon class="collapsable__trigger-icon icon ' +
-            this.config.selectors.iconClassOpen + '"></span>')
-        .append('<span class="visually-hidden" data-dough-collapsable-label>' +
-            this.config.i18nStrings.open + '</span>')
+          this.config.selectors.iconClassOpen + '"></span>')
+        .append('<span class="' +
+          (this.config.showLabels ? 'collapsable-icon-label' : 'visually-hidden') +
+          '" data-dough-collapsable-label>' +
+          this.config.i18nStrings.open + '</span>')
         .attr('aria-controls', id)
         .attr('aria-expanded', 'false');
     this.$target.attr('id', id);

--- a/assets/stylesheets/components/common/_collapsable.scss
+++ b/assets/stylesheets/components/common/_collapsable.scss
@@ -1,9 +1,42 @@
 // Collapsible sections. The first section will automatically be set to open on load, with any further sections closed (collapsed).
 //
 // Styleguide Collapsable
+.collapsable-button--show-label {
+  min-height: 30px;
+}
+
 .js .collapsable__target {
   display: none;
   &.is-active {
     display: block;
+  }
+}
+
+.collapsable-icon-label {
+  font-size: 12px;
+  position: absolute;
+  top: 0;
+  text-align: center;
+  min-width: 30px;
+}
+
+.collapsable--icon-right {
+  position: relative;
+  width: 100%;
+
+  .collapsable-button {
+    display: block;
+    width: 100%;
+    text-align: left;
+  }
+
+  .collapsable-icon-label {
+    right: 5px;
+  }
+
+  .collapsable__trigger-icon {
+    position: absolute;
+    right: 5px;
+    top: 15px;
   }
 }

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.14.0'
+  VERSION = '5.15.0'
 end

--- a/spec/js/fixtures/Collapsable.html
+++ b/spec/js/fixtures/Collapsable.html
@@ -66,3 +66,23 @@
   </h2>
   <div class="target" data-dough-collapsable-target="2">Content</div>
 </div>
+
+<div class="fixture" id="fixture-7">
+  <h2 class="trigger"
+    data-dough-component="Collapsable"
+    data-dough-collapsable-trigger="1"
+    data-dough-collapsable-config='{"showLabels": true}'>
+    Heading
+  </h2>
+  <div class="target" data-dough-collapsable-target="1">Content</div>
+</div>
+
+<div class="fixture" id="fixture-8">
+  <h2 class="trigger"
+    data-dough-component="Collapsable"
+    data-dough-collapsable-trigger="1"
+    data-dough-collapsable-config='{"iconPosition": "right"}'>
+    Heading
+  </h2>
+  <div class="target" data-dough-collapsable-target="1">Content</div>
+</div>

--- a/spec/js/tests/Collapsable_spec.js
+++ b/spec/js/tests/Collapsable_spec.js
@@ -46,6 +46,7 @@ describe('Visibility toggler', function() {
     });
 
     it('adds visually hidden text to indicate the state of the button i.e open or closed', function() {
+      expect(this.$triggerLabel).to.have.class('visually-hidden');
       expect(this.$triggerLabel).to.have.text('Show');
       this.$trigger.click();
       expect(this.$triggerLabel).to.have.text('Hide');
@@ -162,4 +163,32 @@ describe('Visibility toggler', function() {
       expect(this.$target.last().attr('class')).to.equal('target');
     });
   });
+
+
+  describe('Show labels attribute', function() {
+    beforeEach(function(done) {
+      var fixtureHTML = $(window.__html__['spec/js/fixtures/Collapsable.html']).filter('#fixture-7').html();
+      this.beforeEachHook.call(this, done, fixtureHTML);
+    });
+
+    it('does not have the hidden class', function() {
+      expect(this.$triggerLabel).to.not.have.class('visually-hidden');
+    });
+
+    it('has the expected class', function() {
+      expect(this.$triggerLabel).to.have.class('collapsable-icon-label');
+    });
+  });
+
+  describe('Icon position attribute', function() {
+    beforeEach(function(done) {
+      var fixtureHTML = $(window.__html__['spec/js/fixtures/Collapsable.html']).filter('#fixture-8').html();
+      this.beforeEachHook.call(this, done, fixtureHTML);
+    });
+
+    it('Has the icon-right class', function() {
+      expect(this.$trigger).to.have.class('visually-hidden');
+    });
+  });
+
 });


### PR DESCRIPTION
For the Budget Planner redesign the Collapsable Dough component is used extensively. This PR adds two config options to the component:

1. The option to specify whether the dropdown icon appears on the left or the right
2. The option to show the 'show / hide' label (previously this was accessibly hidden)

With both enabled:
![image](https://cloud.githubusercontent.com/assets/14920201/14607915/8e1a5670-057b-11e6-9cbf-952f87e194de.png)

