### PR TITLE
Removing 'only' command and fixing test

### DIFF
--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.16.0'
+  VERSION = '5.16.1'
 end

--- a/spec/js/tests/CollapsableMobile_spec.js
+++ b/spec/js/tests/CollapsableMobile_spec.js
@@ -1,4 +1,4 @@
-describe.only('Visibility toggler on Mobile', function() {
+describe('Visibility toggler on Mobile', function() {
 
   'use strict';
 

--- a/spec/js/tests/Collapsable_spec.js
+++ b/spec/js/tests/Collapsable_spec.js
@@ -187,7 +187,7 @@ describe('Visibility toggler', function() {
     });
 
     it('Has the icon-right class', function() {
-      expect(this.$trigger).to.have.class('visually-hidden');
+      expect(this.$triggerLabel).to.have.class('visually-hidden');
     });
   });
 


### PR DESCRIPTION
In a previous PR I accidentally committed an 'only' command to the Karma tests in Dough (d'oh!). This PR removes this and fixes a test.