### PR TITLE
Dough Collapsable modules show content whilst page renders

### DIFF
--- a/assets/js/components/Collapsable.js
+++ b/assets/js/components/Collapsable.js
@@ -85,6 +85,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises'], function($, Dough
         .attr('aria-controls', id)
         .attr('aria-expanded', 'false');
     this.$target.attr('id', id);
+    this.$target.addClass('collapsable__target--initialised');
 
     this.$triggers = this.$triggers.find('button');
   };

--- a/assets/stylesheets/components/common/_collapsable.scss
+++ b/assets/stylesheets/components/common/_collapsable.scss
@@ -5,7 +5,7 @@
   min-height: 30px;
 }
 
-.js .collapsable__target {
+.js .collapsable__target.collapsable__target--initialised {
   display: none;
   &.is-active {
     display: block;

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.16.1'
+  VERSION = '5.16.2'
 end

--- a/spec/js/tests/Collapsable_spec.js
+++ b/spec/js/tests/Collapsable_spec.js
@@ -157,10 +157,10 @@ describe('Visibility toggler', function() {
 
     it('collapsables in a group should close when one of them is clicked', function() {
       this.$sandbox.find('button').last().click();
-      expect(this.$target.first().attr('class')).to.equal('target');
+      expect(this.$target.first()).to.have.class('target');
 
       this.$sandbox.find('button').first().click();
-      expect(this.$target.last().attr('class')).to.equal('target');
+      expect(this.$target.last()).to.have.class('target');
     });
   });
 


### PR DESCRIPTION
## What?

This PR causes the content of a 'collapsable' module to be visible on the page before JavaScript is being loaded. When the Dough component is initialised, anything that should be hidden gets hidden.

## Why?

The previous behaviour was that if JS was enabled, any 'collapsable' content would be hidden by the CSS, and only shown once JS was initialised. This meant a longer wait for users to see content, as well as the risk that any JS errors / failure to load would result in hidden content.

### Page loading (before this PR):

![vneielwzzf](https://cloud.githubusercontent.com/assets/14920201/15215208/364ffa2c-1849-11e6-95a3-db2d636a3847.gif)

### Page loading now:

![9hjoxlqdti](https://cloud.githubusercontent.com/assets/14920201/15215269/8925e20c-1849-11e6-9855-1e13b406235e.gif)


