### PR TITLE
[DEV APPROVED] TP: 7569, Comment: Updates element that has focus after search

### DIFF
--- a/assets/js/components/SearchFocus.js
+++ b/assets/js/components/SearchFocus.js
@@ -1,0 +1,64 @@
+/**
+ * Search Focus
+ *
+ * Requires an element to have a data-dough-component="SearchFocus" attribute.
+ *
+ * This checks the search results page and shifts the focus of the page depending on its content:
+ * - if a set of results is listed focus is on the first of these
+ * - if there are no results focus is on the input field
+ *
+ * @module SearchFocus
+ * @returns {class} SearchFocus
+ */
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+  'use strict';
+
+  var SearchFocus,
+      defaultConfig = {
+          selectors: {
+          searchResultsItem: '[data-dough-search-results-item]',
+          noResults: '[data-dough-search-noresults]',
+          searchInput: '[data-dough-search-input]'
+        }
+      };
+
+  /**
+   * @constructor
+   * @extends {DoughBaseComponent}
+   * @returns {SearchFocus}
+   */
+  SearchFocus = function($el, config) {
+    SearchFocus.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.results = this.$el.find(this.config.selectors.searchResultsItem);
+    this.noresults = this.$el.find(this.config.selectors.noResults);
+    this.searchInput = this.$el.find(this.config.selectors.searchInput);
+  };
+
+  DoughBaseComponent.extend(SearchFocus);
+
+  SearchFocus.componentName = 'SearchFocus';
+
+  /**
+   * Initialise component
+   * @param {Object} initialised Promise passed from eventsWithPromises (RSVP Promise).
+   */
+  SearchFocus.prototype.init = function(initialised) {
+    this._checkResults();
+    this._initialisedSuccess(initialised);
+  };
+
+  SearchFocus.prototype._checkResults = function() {
+    var focussedElement;
+
+    if (this.results.length) {
+      focussedElement = this.results[0].getElementsByTagName('a')[0];
+    } else if (this.noresults.length) {
+      focussedElement = this.searchInput[0];
+    }
+
+    $(focussedElement).focus();
+  };
+
+  return SearchFocus;
+});

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.18.0'
+  VERSION = '5.19.0'
 end

--- a/spec/js/fixtures/SearchFocus.html
+++ b/spec/js/fixtures/SearchFocus.html
@@ -1,0 +1,35 @@
+<div>
+  <div class="fixture" id="results">
+    <div data-dough-component="SearchFocus">
+      <form>
+        <span>
+          <input data-dough-search-input>
+        </span>
+      </form>
+
+      <ol class="search-results">
+        <li data-dough-search-results-item>
+          <h2><a href="#">Result 1 heading</a></h2>
+          <p>Result 1 text</p>
+        </li>
+
+        <li data-dough-search-results-item>
+          <h2><a href="#">Result 2 heading</a></h2>
+          <p>Result 2 text</p>
+        </li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="fixture" id="no-results">
+    <div data-dough-component="SearchFocus">
+    <form>
+      <span>
+        <input data-dough-search-input>
+      </span>
+    </form>
+
+    <p data-dough-search-noresults>No results text</p>
+    </div>
+  </div>
+</div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -28,6 +28,7 @@ require.config({
     Print: 'assets/js/components/Print',
     TabSelector: 'assets/js/components/TabSelector',
     RangeInput: 'assets/js/components/RangeInput',
+    SearchFocus: 'assets/js/components/SearchFocus',
     FieldHelpText: 'assets/js/components/FieldHelpText',
     Validation: 'assets/js/components/Validation',
     jquery: 'vendor/assets/bower_components/jquery/dist/jquery',

--- a/spec/js/tests/SearchFocus_spec.js
+++ b/spec/js/tests/SearchFocus_spec.js
@@ -1,0 +1,51 @@
+describe('Sets focus after search', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    requirejs(
+      ['jquery', 'SearchFocus'], function($, SearchFocus) {
+        self.$html = $(window.__html__['spec/js/fixtures/SearchFocus.html']).appendTo('body');
+        self.SearchFocus = SearchFocus;
+
+        done();
+      }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('Returns results', function() {
+    beforeEach(function(done) {
+      this.fixtureHTML = $(this.$html).find('#results');
+      this.resultHeader = $(this.fixtureHTML).find('a').get(0);
+      this.component = $(this.fixtureHTML).find('[data-dough-component="SearchFocus"]');
+      this.searchFocus = new this.SearchFocus(this.component);
+      this.searchFocus.init();
+
+      done();
+    });
+
+    it('checks for returned results', function() {
+      expect(this.resultHeader).to.equal(document.activeElement);
+    });
+  });
+
+  describe('Returns no results', function() {
+    beforeEach(function(done) {
+      this.fixtureHTML = $(this.$html).find('#no-results');
+      this.inputField = $(this.fixtureHTML).find('[data-dough-search-input]').get(0);
+      this.component = $(this.fixtureHTML).find('[data-dough-component="SearchFocus"]');
+      this.searchFocus = new this.SearchFocus(this.component);
+      this.searchFocus.init();
+
+      done();
+    });
+
+    it('checks for returned results', function() {
+      expect(this.inputField).to.equal(document.activeElement);
+    });
+  });
+});


### PR DESCRIPTION
This addresses an accessibility issue whereby the focus after a search returns to the top of the page rather than to the first result or, where there are no results, to the input field. 

It is used by PR 1518 in frontend (https://github.com/moneyadviceservice/frontend/pull/1518)