### PR TITLE
[DEV APPROVED]Increasing CSS specificity in collapsable mobile

### DIFF
--- a/assets/stylesheets/components/common/_collapsable-mobile.scss
+++ b/assets/stylesheets/components/common/_collapsable-mobile.scss
@@ -17,7 +17,7 @@
     }
   }
 
-  .collapsable__target {
+  .collapsable__target.collapsable__target--initialised {
     display: none;
 
     @include respond-to($mq-m) {

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.20.0'
+  VERSION = '5.20.1'
 end


### PR DESCRIPTION
The CSS for the 'collapsable' Dough component was slightly more specific than the 'collapsable-mobile' component. This meant that it was overriding it and causing a [bug](https://moneyadviceservice.tpondemand.com/entity/7707) where the 'collapsable-target' container was always hidden on desktop.

This PR makes the CSS for 'collapsable-mobile' slightly more specific. It needs to be able to override the 'collapsable' module, not the other way around.

