### PR TITLE
[DEV APPROVED]Removing SCSS errors - @extends that don't exist

### DIFF
--- a/assets/stylesheets/components/common/_validation_summary.scss
+++ b/assets/stylesheets/components/common/_validation_summary.scss
@@ -5,12 +5,5 @@
 }
 
 .validation-summary__content-container {
-  @extend .is-errored;
   background: $color-validation-summary-background;
-}
-
-.validation-summary__title {
-}
-
-.validation-summary__list {
 }

--- a/assets/stylesheets/components/optional/_tab_selector.scss
+++ b/assets/stylesheets/components/optional/_tab_selector.scss
@@ -35,7 +35,6 @@
   }
 
   .tab-selector__trigger {
-    @extend %type;
     border-color: $color-tab-selector-border;
     border-style: solid;
     bottom: -1px;

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.20.1'
+  VERSION = '5.20.2'
 end


### PR DESCRIPTION
This PR just fixes an SCSS `@extend` that doesn't exist, currently this just gives a warning, but it prevents us from upgrading our SASS-Rails gem.