### PR TITLE
[DEV APPROVED] 7708 - Adding data attributes to social links

### DIFF
--- a/app/views/dough/helpers/social_sharing_icons/_social_sharing_icons.html.erb
+++ b/app/views/dough/helpers/social_sharing_icons/_social_sharing_icons.html.erb
@@ -6,6 +6,7 @@
       <a class="social-sharing__item__icon"
         href="https://www.facebook.com/sharer.php?u=<%= url %>"
         target="_blank"
+        data-dough-shared-on="Facebook"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--facebook svg-icon--facebook" viewBox="26.924 6.373 14.153 27.255" aria-labelledby="social-sharing-facebook" focusable="false">
           <title id="social-sharing-facebook"><%= label_facebook %></title>
@@ -18,6 +19,7 @@
       <a class="social-sharing__item__icon"
         href="https://twitter.com/share?text=<%= text %>&amp;url=<%= url %>"
         target="_blank"
+        data-dough-shared-on="Twitter"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--twitter svg-icon--twitter" viewBox="21.674 9.982 24.653 20.035" aria-labelledby="social-sharing-twitter" focusable="false">
           <title id="social-sharing-twitter"><%= label_twitter %></title>
@@ -29,6 +31,7 @@
     </li><li class="social-sharing__item social-sharing__item--email">
       <a class="social-sharing__item__icon"
         href="mailto:?subject=<%= text %>&amp;body=<%= url %>"
+        data-dough-shared-on="Email"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--email svg-icon--email" viewBox="18.375 10.556 31.249 18.889" aria-labelledby="social-sharing-email" focusable="false">
           <title id="social-sharing-email"><%= label_email %></title>

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.20.2'
+  VERSION = '5.21.2'
 end

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.21.2'
+  VERSION = '5.21.0'
 end


### PR DESCRIPTION
## 7708 - Adding data attributes to social links

Adding ``data-dough-shared-on`` attributes to each of the social links, these will be used in the frontend branch:

https://github.com/moneyadviceservice/frontend/compare/feature/feedback-like-dislike-articles

We will use these to record which of the social media links have been used to share an article