### PR TITLE
[DEV APPROVED]7756 - Adding modified validation - no link

### DIFF
--- a/assets/js/components/Validation.js
+++ b/assets/js/components/Validation.js
@@ -23,6 +23,7 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
         validationSummaryErrorClass: 'validation-summary__error',
         inlineErrorClass: 'js-inline-error',
         showValidationSummary: true,
+        showValidationSummaryLinks: true,
         showInlineValidation: true,
         uiEvents: {
           'blur input, select, textarea': '_handleBlurEvent',
@@ -166,8 +167,14 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
 
     $.each(this.errors, $.proxy(function(errorIndex, fieldGroupValidity) {
       fieldName = fieldGroupValidity.name;
-      summaryHTML += '<li class="' + this.config.validationSummaryErrorClass + '"><a href="#' +
+      if (!this.config.showValidationSummaryLinks) {
+        summaryHTML += '<li class="' + this.config.validationSummaryErrorClass + '--no-link">' +
+                        fieldGroupValidity.message + '</li>';
+      } else {
+        summaryHTML += '<li class="' + this.config.validationSummaryErrorClass + '"><a href="#' +
                       this._getInlineErrorID(fieldName) + '">' + fieldGroupValidity.message + '</a></li>';
+      }
+
     }, this));
 
     this.$el.find('[' + this.config.validationSummaryListAttribute + ']').html(summaryHTML);

--- a/assets/stylesheets/components/common/_validation_summary.scss
+++ b/assets/stylesheets/components/common/_validation_summary.scss
@@ -7,3 +7,7 @@
 .validation-summary__content-container {
   background: $color-validation-summary-background;
 }
+
+.validation-summary__error--no-link {
+  color: $color-validation-text;
+}

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.21.0'
+  VERSION = '5.22.0'
 end


### PR DESCRIPTION
## Adding a modified version of the validation error

In the RAD ticket (https://github.com/moneyadviceservice/rad_consumer/pull/309) we are using the dough validation component, however we do not need the link on the validation text as shown below:

<img src="https://cloud.githubusercontent.com/assets/13165846/20671867/0453d5b8-b577-11e6-851c-6d79b27e8387.png" width="400" />

This PR adds a modified version which will not add a link and anchor to the validation error message:

(Below screenshot shown with additional style added in rad_consumer)

<img src="https://cloud.githubusercontent.com/assets/13165846/20671940/5e3139d6-b577-11e6-884e-cdeb8b749a6e.png" width="400" />
