### PR TITLE
[DEV APPROVED] 7847 - Adding SVG Icon classes

### DIFF
--- a/app/views/dough/helpers/social_sharing_icons/_social_sharing_icons.html.erb
+++ b/app/views/dough/helpers/social_sharing_icons/_social_sharing_icons.html.erb
@@ -8,7 +8,7 @@
         target="_blank"
         data-dough-shared-on="Facebook"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--facebook svg-icon--facebook" viewBox="26.924 6.373 14.153 27.255" aria-labelledby="social-sharing-facebook" focusable="false">
+        <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--facebook svg-icon svg-icon--facebook" viewBox="26.924 6.373 14.153 27.255" aria-labelledby="social-sharing-facebook" focusable="false">
           <title id="social-sharing-facebook"><%= label_facebook %></title>
           <path d="M36.107 33.623v-12.43h4.174l.625-4.846h-4.797v-3.09c0-1.404.392-2.36 2.402-2.36l2.564-.002V6.563c-.442-.059-1.967-.19-3.737-.19-3.697 0-6.233 2.256-6.233 6.405v3.572h-4.183v4.845h4.183v12.433h5.003l-.001-.005z"/>
         </svg>
@@ -21,7 +21,7 @@
         target="_blank"
         data-dough-shared-on="Twitter"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--twitter svg-icon--twitter" viewBox="21.674 9.982 24.653 20.035" aria-labelledby="social-sharing-twitter" focusable="false">
+        <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--twitter svg-icon svg-icon--twitter" viewBox="21.674 9.982 24.653 20.035" aria-labelledby="social-sharing-twitter" focusable="false">
           <title id="social-sharing-twitter"><%= label_twitter %></title>
           <path d="M46.326 12.592c-.904.402-1.883.674-2.904.796 1.045-.625 1.846-1.617 2.225-2.796-.98.579-2.062 1-3.215 1.226-.922-.982-2.238-1.597-3.691-1.597-2.793 0-5.058 2.264-5.058 5.058 0 .396.044.783.131 1.153-4.204-.211-7.93-2.224-10.425-5.283-.435.746-.685 1.614-.685 2.542 0 1.754.893 3.303 2.25 4.21-.828-.025-1.608-.253-2.291-.632v.064c0 2.451 1.743 4.493 4.056 4.958-.423.115-.87.176-1.332.176-.325 0-.642-.033-.95-.094.643 2.012 2.511 3.475 4.724 3.514-1.73 1.357-3.912 2.166-6.282 2.166-.407 0-.81-.021-1.206-.07 2.239 1.438 4.896 2.273 7.752 2.273 9.303 0 14.391-7.707 14.391-14.391 0-.219-.006-.437-.016-.654.991-.715 1.848-1.606 2.526-2.619z"/>
         </svg>
@@ -33,7 +33,7 @@
         href="mailto:?subject=<%= text %>&amp;body=<%= url %>"
         data-dough-shared-on="Email"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--email svg-icon--email" viewBox="18.375 10.556 31.249 18.889" aria-labelledby="social-sharing-email" focusable="false">
+        <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--email svg-icon svg-icon--email" viewBox="18.375 10.556 31.249 18.889" aria-labelledby="social-sharing-email" focusable="false">
           <title id="social-sharing-email"><%= label_email %></title>
           <path d="M36.036 24.748c-1.021.971-2.7.98-3.731.02L20.449 13.694c-1.03-.963-1.919-1.768-1.974-1.792-.055-.023-.099 1.112-.099 2.522v12.457c0 1.41 1.154 2.564 2.565 2.564h26.122c1.408 0 2.562-1.154 2.562-2.564v-12.46c0-1.411-.039-2.533-.085-2.495-.052.039-.924.866-1.946 1.838L36.036 24.748zM47.295 10.556c-.158 0-19.764.046-26.055.038-1.061 0-2.039.023-1.851.209.282.283.455.419 1 .913 2.74 2.583 9.525 8.757 10.601 9.937 2.507 2.76 3.729 2.811 6.154.192.221-.239 11.237-10.729 11.467-10.959.221-.216-.244-.33-1.316-.33z"/>
         </svg>

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.22.0'
+  VERSION = '5.22.1'
 end


### PR DESCRIPTION
This PR adds the generic `.svg-icon` class that we use in Frontend for styling SVG Icons.