### PR TITLE
[DEV APPROVED] Reverting rails version to pre 5 to avoid cache bug

### DIFF
--- a/dough-ruby.gemspec
+++ b/dough-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     ['LICENSE', 'Rakefile', 'README.md', 'bower.json', '.jscsrc', '.jshintrc']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '>= 3.2'
+  s.add_dependency 'rails', '>= 3.2', '< 5'
   s.add_dependency 'sass-rails'
   s.add_dependency 'activesupport'
 end

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.24.0'
+  VERSION = '5.24.1'
 end


### PR DESCRIPTION
Dough is failing on the test because of a known error in the later version of rails:

https://github.com/rails/rails/issues/28529

This PR reverts the version back to a pre v5 Version and fixes the error