### PR TITLE
8380 - Adding popup tooltip

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -1,0 +1,59 @@
+define(['jquery', 'DoughBaseComponent'],
+  function($, DoughBaseComponent) {
+  'use strict';
+
+  var defaultConfig = {
+        selectors: {
+          trigger:       '[data-dough-popup-trigger]',
+          popupContent:  '[data-dough-popup-content]',
+          popupClose:    '[data-dough-popup-close]',
+          activeClass:   'is-active',
+          inactiveClass: 'is-inactive',
+        }
+      },
+      PopupTip;
+
+  PopupTip = function($el, config) {
+    PopupTip.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.$trigger = this.$el.find(this.config.selectors.trigger);
+    this.$popup   = this.$el.find(this.config.selectors.popupContent);
+
+    return this;
+  };
+
+  DoughBaseComponent.extend(PopupTip);
+  PopupTip.componentName = 'PopupTip';
+
+  PopupTip.prototype._addEvents = function() {
+    var $closeBtn = this.$el.find(this.config.selectors.popupClose);
+
+    this.$trigger.on('click', $.proxy(this.showPopupTip, this));
+    $closeBtn.on('click', $.proxy(this.hidePopupTip, this));
+  };
+
+  PopupTip.prototype.showPopupTip = function() {
+    var triggerPos    = this.$trigger.offset();
+
+    this.$popup.css({
+      'top' : triggerPos.top
+    });
+
+    this.$popup.removeClass(this.config.selectors.inactiveClass);
+    this.$popup.addClass(this.config.selectors.activeClass);
+  };
+
+  PopupTip.prototype.hidePopupTip = function() {
+    this.$popup.addClass(this.config.selectors.inactiveClass);
+    this.$popup.removeClass(this.config.selectors.activeClass);
+  };
+
+  PopupTip.prototype.init = function(initialised) {
+    this._addEvents();
+    this._initialisedSuccess(initialised);
+
+    return this;
+  };
+
+  return PopupTip;
+});

--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -1,0 +1,47 @@
+.popup-tip__button {
+  background-color: transparent;
+  border: none;
+  font-weight: 700;
+  font-style: italic;
+  position: relative;
+}
+
+.popup-tip__content {
+  display: none;
+  padding: $baseline-unit*2;
+  border: 2px solid $color-grey-dark;
+  background-color: $color-white;
+  z-index: 1;
+  position: absolute;
+  left: $baseline-unit;
+
+  &.is-inactive {
+    display: none;
+  }
+
+  &.is-active {
+    display: block;
+  }
+
+  @include respond-to($mq-m) {
+    max-width: 300px;
+  }
+}
+
+.popup-tip__title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.popup-tip__close {
+  position: absolute;
+  top: -15px;
+  right: -15px;
+  background-color: $color-white;
+  border: 2px solid $color-grey-dark;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  padding: 1px;
+}

--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -1,30 +1,38 @@
 .popup-tip__button {
+  display: none;
   background-color: transparent;
   border: none;
   font-weight: 700;
   font-style: italic;
   position: relative;
+
+  .js & {
+    display: inline;
+  }
 }
 
 .popup-tip__content {
-  display: none;
-  padding: $baseline-unit*2;
-  border: 2px solid $color-grey-dark;
-  background-color: $color-white;
-  z-index: 1;
-  position: absolute;
-  left: $baseline-unit;
 
-  &.is-inactive {
+  .js & {
+    padding: $baseline-unit*2;
     display: none;
-  }
+    border: 2px solid $color-grey-dark;
+    background-color: $color-white;
+    z-index: 1;
+    position: absolute;
+    left: $baseline-unit;
 
-  &.is-active {
-    display: block;
-  }
+    &.is-inactive {
+      display: none;
+    }
 
-  @include respond-to($mq-m) {
-    max-width: 300px;
+    &.is-active {
+      display: block;
+    }
+
+    @include respond-to($mq-m) {
+      max-width: 300px;
+    }
   }
 }
 
@@ -35,7 +43,7 @@
 }
 
 .popup-tip__close {
-  position: absolute;
+  display: none;
   top: -15px;
   right: -15px;
   background-color: $color-white;
@@ -44,4 +52,9 @@
   height: 30px;
   border-radius: 50%;
   padding: 1px;
+
+  .js & {
+    display: inline;
+    position: absolute;
+  }
 }

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.24.1'
+  VERSION = '5.25.0'
 end

--- a/spec/js/fixtures/PopupTip.html
+++ b/spec/js/fixtures/PopupTip.html
@@ -1,0 +1,13 @@
+<div data-dough-component="PopupTip">
+  <button data-dough-popup-trigger type="button"></button>
+  <div data-dough-popup-content>
+    <h3>Title</h3>
+    <p>Content</p>
+    <button data-dough-popup-close type="button">
+      <span aria-hidden="true">X</span>
+      <span class="visually-hidden">
+        Close
+      </span>
+    </button>
+  </div>
+</div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -25,6 +25,7 @@ require.config({
     Collapsable: 'assets/js/components/Collapsable',
     CollapsableMobile: 'assets/js/components/CollapsableMobile',
     ConfirmableForm: 'assets/js/components/ConfirmableForm',
+    PopupTip: 'assets/js/components/PopupTip',
     Print: 'assets/js/components/Print',
     TabSelector: 'assets/js/components/TabSelector',
     RangeInput: 'assets/js/components/RangeInput',

--- a/spec/js/tests/PopupTip_spec.js
+++ b/spec/js/tests/PopupTip_spec.js
@@ -1,0 +1,52 @@
+describe('Displays Popup Tooltip', function() {
+  'use strict';
+
+  var activeClass   = 'is-active',
+      inactiveClass = 'is-inactive';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    requirejs(
+      ['jquery', 'PopupTip'], function($, PopupTip) {
+        self.$html    = $(window.__html__['spec/js/fixtures/PopupTip.html']).appendTo('body');
+        self.PopupTip = PopupTip;
+        
+        done();
+      }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('Default behaviour', function() {
+
+    beforeEach(function(done) {
+      this.$html    = $(window.__html__['spec/js/fixtures/PopupTip.html']);
+      this.$trigger = this.$html.find('[data-dough-popup-trigger]');
+      this.$content = this.$html.find('[data-dough-popup-content]');
+      this.$close   = this.$html.find('[data-dough-popup-close]');
+      this.popupTip = new this.PopupTip(this.$html);
+      this.popupTip.init();
+
+      done();
+    });
+
+    it('hides the popup content on load', function() {
+      expect(this.$content).to.not.have.class(activeClass);    
+    });
+
+    it('displays the popup on trigger click', function() {
+      this.$trigger.click();
+      expect(this.$content).to.have.class(activeClass); 
+    });
+
+    it('closes the popup on close button click', function() {
+      this.$close.click();
+      expect(this.$content).to.have.class(inactiveClass);
+    });
+
+  });
+
+});


### PR DESCRIPTION
# Adds Popup Tooltip component to Dough

This PR adds a new component for a popup tooltip.

| Screenshot |
|------------|
<img src="https://user-images.githubusercontent.com/13165846/28117890-09f6d15e-6707-11e7-9ac7-e6bbd2df3f49.png" width="300" />|

## Usage

```
<div data-dough-component="PopupTip">
  <button data-dough-popup-trigger type="button" class="popup-tip__button">
    <!-- Anything can be used for the trigger, an icon, text -->
  </button>
  <div data-dough-popup-content class="popup-tip__content">
    <h3 class="popup-tip__title">Title</h3>
    <p>Content</p>
    <button data-dough-popup-close type="button" class="popup-tip__close">
      <span aria-hidden="true">
        <!-- Icon, text or image for close will be defined in frontend and use the spritesheet -->
      </span>
      <span class="visually-hidden">
        <!-- Close text controlled by YAML's for language change -->
      </span>
    </button>
  </div>
</div>
```

## No JS fallback

**Using WPCC as an example**

![image](https://user-images.githubusercontent.com/13165846/28157339-15ffbe1e-67ae-11e7-9562-0fd4dd48e39d.png)
