### PR TITLE
Fixes spacing error

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -36,7 +36,7 @@ define(['jquery', 'DoughBaseComponent'],
     var triggerPos    = this.$trigger.offset();
 
     this.$popup.css({
-      'top' : triggerPos.top
+      'top': triggerPos.top
     });
 
     this.$popup.removeClass(this.config.selectors.inactiveClass);


### PR DESCRIPTION
Fixes the below error on the build server:

```
09:57:18.493 Illegal space after key at assets/js/components/PopupTip.js :
09:57:18.493     37 |
09:57:18.493     38 |    this.$popup.css({
09:57:18.493     39 |      'top' : triggerPos.top
09:57:18.494 -------------------^
09:57:18.494     40 |    });
09:57:18.494     41 |
09:57:18.494 
09:57:18.495 
09:57:18.495 1 code style error found.
09:57:18.516 [go] Current job status: failed.
```