### PR TITLE
8380 - Adjust how tooltip is positioned

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -33,12 +33,6 @@ define(['jquery', 'DoughBaseComponent'],
   };
 
   PopupTip.prototype.showPopupTip = function() {
-    var triggerPos    = this.$trigger.offset();
-
-    this.$popup.css({
-      'top': triggerPos.top
-    });
-
     this.$popup.removeClass(this.config.selectors.inactiveClass);
     this.$popup.addClass(this.config.selectors.activeClass);
   };

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.25.0'
+  VERSION = '5.25.1'
 end


### PR DESCRIPTION
## 8380 - Adjust how tooltip is positioned

Currently the component calculates the position from the top of the page to the trigger, this isnt a good approach, this PR removes this calculation.  It will be less intensive to use CSS positioning instead.