### PR TITLE
[DEV APPROVED] Improves screen reader accessibility- PopupTip.js

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -4,11 +4,12 @@ define(['jquery', 'DoughBaseComponent'],
 
   var defaultConfig = {
         selectors: {
-          trigger:       '[data-dough-popup-trigger]',
-          popupContent:  '[data-dough-popup-content]',
-          popupClose:    '[data-dough-popup-close]',
-          activeClass:   'is-active',
-          inactiveClass: 'is-inactive',
+          trigger:        '[data-dough-popup-trigger]',
+          popupContainer: '[data-dough-popup-container]',
+          popupContent:   '[data-dough-popup-content]',
+          popupClose:     '[data-dough-popup-close]',
+          activeClass:    'is-active',
+          inactiveClass:  'is-inactive',
         }
       },
       PopupTip;
@@ -17,7 +18,8 @@ define(['jquery', 'DoughBaseComponent'],
     PopupTip.baseConstructor.call(this, $el, config, defaultConfig);
 
     this.$trigger = this.$el.find(this.config.selectors.trigger);
-    this.$popup   = this.$el.find(this.config.selectors.popupContent);
+    this.$popup   = this.$el.find(this.config.selectors.popupContainer);
+    this.$popupContent = this.$el.find(this.config.selectors.popupContent);
 
     return this;
   };
@@ -28,18 +30,20 @@ define(['jquery', 'DoughBaseComponent'],
   PopupTip.prototype._addEvents = function() {
     var $closeBtn = this.$el.find(this.config.selectors.popupClose);
 
-    this.$trigger.on('click', $.proxy(this.showPopupTip, this));
-    $closeBtn.on('click', $.proxy(this.hidePopupTip, this));
+    this.$trigger.click($.proxy(this.showPopupTip, this));
+    $closeBtn.click($.proxy(this.hidePopupTip, this));
   };
 
   PopupTip.prototype.showPopupTip = function() {
     this.$popup.removeClass(this.config.selectors.inactiveClass);
     this.$popup.addClass(this.config.selectors.activeClass);
+    this.$popupContent.attr('tabindex', -1).focus();
   };
 
   PopupTip.prototype.hidePopupTip = function() {
     this.$popup.addClass(this.config.selectors.inactiveClass);
     this.$popup.removeClass(this.config.selectors.activeClass);
+    this.$trigger.focus();
   };
 
   PopupTip.prototype.init = function(initialised) {

--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -11,8 +11,8 @@
   }
 }
 
-.popup-tip__content {
-
+.popup-tip__container {
+  
   .js & {
     padding: $baseline-unit*2;
     display: none;
@@ -34,6 +34,10 @@
       max-width: 300px;
     }
   }
+}
+
+.popup-tip__content {
+  outline: none;
 }
 
 .popup-tip__title {

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.25.1'
+  VERSION = '5.25.2'
 end

--- a/spec/js/fixtures/PopupTip.html
+++ b/spec/js/fixtures/PopupTip.html
@@ -1,8 +1,7 @@
 <div data-dough-component="PopupTip">
   <button data-dough-popup-trigger type="button"></button>
-  <div data-dough-popup-content>
-    <h3>Title</h3>
-    <p>Content</p>
+  <div data-dough-popup-container>
+    <p data-dough-popup-content>Content</p>
     <button data-dough-popup-close type="button">
       <span aria-hidden="true">X</span>
       <span class="visually-hidden">

--- a/spec/js/tests/PopupTip_spec.js
+++ b/spec/js/tests/PopupTip_spec.js
@@ -23,28 +23,28 @@ describe('Displays Popup Tooltip', function() {
   describe('Default behaviour', function() {
 
     beforeEach(function(done) {
-      this.$html    = $(window.__html__['spec/js/fixtures/PopupTip.html']);
-      this.$trigger = this.$html.find('[data-dough-popup-trigger]');
-      this.$content = this.$html.find('[data-dough-popup-content]');
-      this.$close   = this.$html.find('[data-dough-popup-close]');
-      this.popupTip = new this.PopupTip(this.$html);
+      this.$html      = $(window.__html__['spec/js/fixtures/PopupTip.html']);
+      this.$trigger   = this.$html.find('[data-dough-popup-trigger]');
+      this.$container = this.$html.find('[data-dough-popup-container]');
+      this.$close     = this.$html.find('[data-dough-popup-close]');
+      this.popupTip   = new this.PopupTip(this.$html);
       this.popupTip.init();
 
       done();
     });
 
     it('hides the popup content on load', function() {
-      expect(this.$content).to.not.have.class(activeClass);    
+      expect(this.$container).to.not.have.class(activeClass);    
     });
 
     it('displays the popup on trigger click', function() {
       this.$trigger.click();
-      expect(this.$content).to.have.class(activeClass); 
+      expect(this.$container).to.have.class(activeClass); 
     });
 
     it('closes the popup on close button click', function() {
       this.$close.click();
-      expect(this.$content).to.have.class(inactiveClass);
+      expect(this.$container).to.have.class(inactiveClass);
     });
 
   });


### PR DESCRIPTION
## Improves the screen reader accessibility of the PopupTip component

This PR makes an improvement to the behaviour of the popuptip component when a user clicks on the show help icon:

1) User clicks button:

<img src="https://user-images.githubusercontent.com/13165846/29017219-d083b0f8-7b4d-11e7-99e2-ce885b6a8857.png" width="400"/>

2) Focus shifts to popuptip content, screen reader will read the contents automatically (Outline is hidden using CSS attribute ``outline: none``)

<img src="https://user-images.githubusercontent.com/13165846/29017274-0d9c3172-7b4e-11e7-84ee-26fe6665cc18.png" width="400"/>

3) On the next tab click, the close button is selected:

<img src="https://user-images.githubusercontent.com/13165846/29017294-291d878e-7b4e-11e7-91e8-718531d009e4.png" width="400"/>

4) Focus is then returned to the help icon, placing the user back to their original point:

<img src="https://user-images.githubusercontent.com/13165846/29017318-43e6e484-7b4e-11e7-94eb-56b6d3e13db0.png" width="400"/>

Please note that this requires a change to the markup of our tools which currently use this component.

New Markup:

```
<!-- Button -->
<button type="button" class="popup-tip__button" data-dough-popup-trigger>
  <span aria-hidden="true">i</span>
  <span class="visually-hidden">show</span>
</button>

<!-- Popup Tip -->
<div data-dough-popup-container class="popup-tip__container">
  <p data-dough-popup-content class="popup-tip__content">
    Popup Tip Content
  </p>
  <button data-dough-popup-close type="button" class="popup-tip__close">
    <span aria-hidden="true">
      <!-- Close icon -->
    </span>
    <span class="visually-hidden">Close</span>
  </button>
</div>
```