### PR TITLE
[DEV APPROVED] 7960, 7970 - Accessibility role link, and aria-hidden in tabs

### DIFF
--- a/assets/js/components/TabSelector.js
+++ b/assets/js/components/TabSelector.js
@@ -172,7 +172,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
           var content = $(this).html(),
               triggerId = $(this).attr(selectors.trigger);
           $(this).replaceWith('<button class="tab-selector__trigger unstyled-button" type="button" ' +
-              selectors.trigger + '="' + triggerId + '">' +
+              selectors.trigger + '="' + triggerId + '" role="link">' +
               content +
               ' <span class="visually-hidden" data-dough-tab-selector-show> ' +
               _this.i18nStrings.show + '</span>' +

--- a/assets/js/components/TabSelector.js
+++ b/assets/js/components/TabSelector.js
@@ -102,7 +102,7 @@ define(['jquery', 'DoughBaseComponent', 'eventsWithPromises', 'mediaQueries'],
        * Any one-off actions to make the component more accessible
        */
       TabSelector.prototype._setupAccessibility = function() {
-        this.$el.find('[' + selectors.target + ']').attr({
+        this.$el.find('[' + selectors.target + '].' + selectors.inactiveClass).attr({
           'aria-hidden': 'true',
           'tabindex': '-1'
         });

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.25.2'
+  VERSION = '5.25.3'
 end

--- a/spec/js/tests/TabSelector_spec.js
+++ b/spec/js/tests/TabSelector_spec.js
@@ -6,7 +6,8 @@ describe('Tab selector', function() {
       triggersInner = '[data-dough-tab-selector-triggers-inner]',
       triggerSelector = '[data-dough-tab-selector-trigger]',
       activeTrigger = triggerSelector + '.' + activeClass,
-      target = '[data-dough-tab-selector-target].' + activeClass + ' .tab-selector__target-heading';
+      target = '[data-dough-tab-selector-target].' + activeClass,
+      inactiveTarget = '[data-dough-tab-selector-target].is-inactive';
 
   beforeEach(function(done) {
     var self = this;
@@ -36,6 +37,14 @@ describe('Tab selector', function() {
     return $root.find(target);
   }
 
+  function activeTargetHeading($root) {
+    return activeTarget($root).find('.tab-selector__target-heading');
+  }
+
+  function inactiveTargets($root) {
+    return $root.find(inactiveTarget);
+  }
+
   describe('general functions', function() {
 
     beforeEach(function(done) {
@@ -48,9 +57,18 @@ describe('Tab selector', function() {
     });
 
     it('selects the first item in the list', function() {
+      var _this = this;
       this.$html.find(activeTrigger).each(function() {
         expect($(this).text()).to.contain('panel 1');
         expect($(this).text()).to.contain('selected');
+
+        expect(activeTarget(_this.$html)).not.to.have.attr('aria-hidden', 'true');
+      });
+    });
+
+    it('sets aria-hidden=true on inactive items', function() {
+      inactiveTargets(this.$html).each(function() {
+        expect($(this)).to.have.attr('aria-hidden', 'true');
       });
     });
 
@@ -71,9 +89,18 @@ describe('Tab selector', function() {
 
     it('shows the associated target panel when a trigger is clicked', function() {
       this.$triggers.last().click();
-      expect(activeTarget(this.$html)).to.have.text('Panel 3');
+      expect(activeTargetHeading(this.$html)).to.have.text('Panel 3');
+      expect(activeTarget(this.$html)).to.have.attr('aria-hidden', 'false');
       this.$triggers.first().click();
-      expect(activeTarget(this.$html)).to.have.text('Panel 1');
+      expect(activeTargetHeading(this.$html)).to.have.text('Panel 1');
+      expect(activeTarget(this.$html)).to.have.attr('aria-hidden', 'false');
+    });
+
+    it('sets aria-hidden to false on other target panels when a trigger is clicked', function() {
+      this.$triggers.last().click();
+      inactiveTargets(this.$html).each(function() {
+        expect($(this)).to.have.attr('aria-hidden', 'true');
+      });
     });
 
     it('updates other copies of the clicked trigger', function() {


### PR DESCRIPTION
This PR addresses two accessibility/usability issues:

**Link role**
[TP Link - 7960](https://moneyadviceservice.tpondemand.com/entity/7960)
![image](https://user-images.githubusercontent.com/689327/29312812-00573644-81af-11e7-8dcf-0c4f2968df62.png)
The tabs shown here are being picked up as buttons by Dragon. This could be confusing for a voice activation user as most tabs are picked up as links by Dragon. **Solution**: use the role of ‘link’ for these elements.

**aria-hidden=true in active tab**
[TP Link 7970](https://moneyadviceservice.tpondemand.com/entity/7970)
This was a bug in the TabSelector component: `aria-hidden` was set to `true` on all tabs when the page loaded, including the active tab. Instead, `aria-hidden` should only be `true` for the inactive tabs.
