### PR TITLE
8647 tooltip icon

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "vendor/assets/bower_components"
+  "directory": "vendor/assets/bower_components",
+  "registry": "https://registry.bower.io"
 }

--- a/app/views/dough/helpers/popup_tip_content/_popup_tip_content.html.erb
+++ b/app/views/dough/helpers/popup_tip_content/_popup_tip_content.html.erb
@@ -1,0 +1,21 @@
+<% if local_assigns[:options] %>
+  <% title = options.fetch(:title, '') %>
+  <% text = options.fetch(:text, '') %>
+  <% classname = options.fetch(:classname, '') %>
+  <% tooltip_hide = options.fetch(:tooltip_hide, '') %>
+<% end %>
+
+<div data-dough-popup-container class="helper popup-tip__container <%= classname %>">
+  <p data-dough-popup-content class="popup-tip__content">
+    <span class="popup-tip__title--no-js"><%= title %>:</span> <%= text %>
+  </p>
+
+  <button data-dough-popup-close type="button" class="popup-tip__close">
+    <span aria-hidden="true">
+      <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
+      </svg>
+    </span>
+    <span class="visually-hidden"><%= tooltip_hide %></span>
+  </button>
+</div>

--- a/app/views/dough/helpers/popup_tip_trigger/_popup_tip_trigger.html.erb
+++ b/app/views/dough/helpers/popup_tip_trigger/_popup_tip_trigger.html.erb
@@ -1,0 +1,11 @@
+<% if local_assigns[:options] %>
+  <% text = options.fetch(:text, '') %>
+  <% classname = options.fetch(:classname, '') %>
+<% end %>
+
+<button type="button"
+        class= "helper popup-tip__button <%= classname %>"
+        data-dough-popup-trigger>
+  <span aria-hidden="true">i</span>
+  <span class="visually-hidden"><%= text %></span>
+</button>

--- a/docs/PopupTip.md
+++ b/docs/PopupTip.md
@@ -1,0 +1,22 @@
+## Popup Tip
+
+### Definition
+Consists of two inter-related elements wrapped in a container:
+* popup_tip_trigger
+* popup_tip_content
+
+The container requires the data-dough-component value of "PopupTip" to be present so that it can use the Dough PopupTip component.
+
+### Rules: popup_tip_trigger
+* text: the text that appears in the visually hidden span that will be used by assistive technology
+* classname: the optional class that is appended to the trigger
+
+### Rules: popup_tip_content
+* title: the optional text that appears at the start of the content of the pop-up as a title
+* text: the textual content of the popup
+* classname: the optional class that is appended to the content container
+* tooltip_hide: the text that appears in the visually hidden span associated with the close icon that will be used by assistive technology
+
+### Examples
+* [Code example](https://github.com/moneyadviceservice/wpcc/blob/master/app/views/wpcc/your_details/new.html.erb)
+* [Live example](https://www.moneyadviceservice.org.uk/en/tools/workplace-pension-contribution-calculator)

--- a/docs/helpers/PopupTipContent.erb
+++ b/docs/helpers/PopupTipContent.erb
@@ -1,0 +1,6 @@
+<%= popup_tip_content
+  title: 'Earnings',
+  text: 'This is the part of your annual pay that will be used to calculate your pension contribution under automatic enrolment',
+  classname: 'earnings',
+  tooltip_hide: 'hide help'
+%>

--- a/docs/helpers/PopupTipTrigger.erb
+++ b/docs/helpers/PopupTipTrigger.erb
@@ -1,0 +1,4 @@
+<%= popup_tip_trigger
+  text: 'show help',
+  classname: 'earnings'
+%>

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.25.3'
+  VERSION = '5.26.0'
 end

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "requirejs": "^2.1.22",
     "sinon": "~1.9.0",
     "sinon-chai": "^2.5.0"
+  },
+  "dependencies": {
+    "bower": "^1.8.2"
   }
 }


### PR DESCRIPTION
[TP8647](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/8479&appConfig=eyJhY2lkIjoiREREN0YzQTYyNjg0NEFCOEQxQkVFM0YwNkVDMjhFRkEifQ==&searchPopup=userstory/8647)

This PR creates two new Dough Helpers that can be used across the site to replace the various tooltips that are used throughout our tools. These are based on the partials created in WPCC and have no styles associated with them.

### popup tip trigger: 
* provides the icon that shows the tip
* allows us to pass in two optional values:
  * the visually-hidden text for screen-readers (e.g. “show help”)
  * a class name which is necessary in some instances on WPCC

### popup tip content: 
* provides the container for the content that is displayed in the tip
* allows us to pass in four optional values: 
  * a title which is used in some instances on WPCC
   * the textual content of the tooltip popup
    * a class which is used in some instances on WPCC
     * the visually-hidden text for screen-readers for the close button (e.g. “hide help”)

This appears as below on WPCC

![image](https://user-images.githubusercontent.com/6080548/33271120-3ebed164-d37e-11e7-9e61-cbf91096aeaf.png)
