### PR TITLE
[DEV APPROVED] TP: 8729, Comment: Disable GitHub pages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,8 @@ export RAILS_ENV=build
 export BUNDLE_WITHOUT="development:test"
 
 npm install
-./node_modules/gulp/bin/gulp.js build
+# Temporary fix to disable github pages which is causing build problems
+# ./node_modules/gulp/bin/gulp.js build
 
 time bundle install
 time bundle exec rake app:gem:build

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.26.0'
+  VERSION = '5.26.1'
 end


### PR DESCRIPTION
[TP8729](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8729)

The main work for this has already been merged but there are build problems that appear to be connected to a known issue with GitHub pages. This means that there will be no documentation for the tooltip helpers on Made with Dough but the helpers should be useable.