### PR TITLE
[DEV APPROVED] 8744 - Tooltip component bug

### DIFF
--- a/app/views/dough/helpers/popup_tip_content/_popup_tip_content.html.erb
+++ b/app/views/dough/helpers/popup_tip_content/_popup_tip_content.html.erb
@@ -7,7 +7,12 @@
 
 <div data-dough-popup-container class="helper popup-tip__container <%= classname %>">
   <p data-dough-popup-content class="popup-tip__content">
-    <span class="popup-tip__title--no-js"><%= title %>:</span> <%= text %>
+    <% if title.present? %>
+      <span class="popup-tip__title--no-js">
+        <%= title %>:
+      </span>
+    <% end %>
+    <%= text %>
   </p>
 
   <button data-dough-popup-close type="button" class="popup-tip__close">

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.26.1'
+  VERSION = '5.26.2'
 end


### PR DESCRIPTION
# 8744 - Tooltip component bug

The popup tip content boxes may include a title element, but most of them do not in practice. 

Where a popup content does not have a title and where JS is disabled - the automatically displayed text starts with a colon, which it shouldn't.
 
This is a ticket to remove the colon in those circumstances.

| Current (Non JS) |
|---------|
|<img width="795" alt="screen shot 2017-12-19 at 10 18 04" src="https://user-images.githubusercontent.com/13165846/34152285-fd75524e-e4a5-11e7-942c-bd39611d0a68.png">|

| Updated with title | Updated no title |
|-------------------|-----------------|
|<img width="730" alt="screen shot 2017-12-19 at 10 20 59" src="https://user-images.githubusercontent.com/13165846/34152395-594b4d30-e4a6-11e7-9049-d304438d31da.png">|<img width="730" alt="screen shot 2017-12-19 at 10 19 40" src="https://user-images.githubusercontent.com/13165846/34152341-296438e8-e4a6-11e7-95c5-a0942ea4b45d.png">|
