### PR TITLE
[DEV APPROVED] 7317 back to top unit tests

### DIFF
--- a/assets/js/components/BackToTop.js
+++ b/assets/js/components/BackToTop.js
@@ -4,7 +4,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
 
   var BackToTop,
       defaultConfig = {
-        definedHeight: 1704,
+        triggerPoint: 1704,
       },
       i18nStrings = {
         title: 'Back to top'
@@ -17,6 +17,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     this.atSmallViewport = false;
     this.linkHeight = 0;
     this.hiddenClass = 'visually-hidden';
+    this.showClass = 'back_to_top__link--shown';
     this.active = false;
     this.scrollingToTop = false;
   };
@@ -41,7 +42,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
         '</svg>' +
       '</a>');
 
-    $(document).find('footer')
+    this.$el.parentsUntil('l-body').parent().find('footer')
       .append(this.$bttLink)
       .find('.l-footer-secondary')
         .addClass('back_to_top__spacer');
@@ -55,7 +56,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
 
     this.$bttLink
       .click(function() {
-        $(this).removeClass('back_to_top__link--shown');
+        $(this).removeClass(self.showClass);
         self.scrollingToTop = true;
 
         $('html, body').animate({scrollTop: 0}, 800, function() {
@@ -65,12 +66,18 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
   };
 
   BackToTop.prototype._getActive = function() {
-    if ($(window).scrollTop() < this.config.definedHeight && !this.scrollingToTop) {
+    var scrollAmount = this._getScrollAmount();
+
+    if (scrollAmount < this.config.triggerPoint && !this.scrollingToTop) {
       this.active = false;
     } else {
       this.active = true;
     }
   };
+
+  BackToTop.prototype._getScrollAmount = function() {
+    return $(window).scrollTop();
+  }
 
   BackToTop.prototype._resize = function() {
     if (mediaQueries.atSmallViewport()) {
@@ -93,12 +100,12 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     if (!this.scrollingToTop) {
       this._getActive();
 
-      if (this.active) {
       // we are beyond the scroll point
-        this.$bttLink.addClass('back_to_top__link--shown');
-      } else {
+      if (this.active) {
+        this.$bttLink.addClass(this.showClass);
       // we are not beyond the scroll point
-        this.$bttLink.removeClass('back_to_top__link--shown');
+      } else {
+        this.$bttLink.removeClass(this.showClass);
       }
     }
   };
@@ -113,4 +120,3 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
 
   return BackToTop;
 });
-

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.26.2'
+  VERSION = '5.26.3'
 end

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "karma-requirejs": "1.1.0",
     "karma-sinon": "^1.0.3",
     "mocha": "^3.4.2",
+    "karma-spec-reporter": "0.0.32",
     "phantomjs-prebuilt": "^2.1.5",
     "requirejs": "~2.2.0",
     "sinon": "^2.3.6",

--- a/spec/js/fixtures/BackToTop.html
+++ b/spec/js/fixtures/BackToTop.html
@@ -1,0 +1,11 @@
+<div>
+  <div>
+    <div>
+      <div data-dough-component="BackToTop"></div>
+    </div>
+
+    <footer>
+      <div class="l-footer-secondary"></div>
+    </footer>
+  </div>
+</div>

--- a/spec/js/karma.conf.js
+++ b/spec/js/karma.conf.js
@@ -3,15 +3,12 @@
 
 module.exports = function(config) {
   config.set({
-
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '../../',
-
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['requirejs', 'mocha', 'chai-jquery', 'chai', 'sinon', 'jquery-1.11.0'],
-
 
     // list of files / patterns to load in the browser
     files: [
@@ -25,12 +22,10 @@ module.exports = function(config) {
       {pattern: 'spec/js/tests/*_spec.js', included: false}
     ],
 
-
     // list of files to exclude
     exclude: [
       'vendor/assets/bower_components/**/test/*.js'
     ],
-
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
@@ -39,12 +34,9 @@ module.exports = function(config) {
       'assets/js/**/*.js': ['coverage']
     },
 
-
     // test results reporter to use
-    // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage', 'osx'],
-
+    reporters: ['spec'],
 
     // configure the reporter
     coverageReporter: {
@@ -55,24 +47,19 @@ module.exports = function(config) {
     // web server port
     port: 9876,
 
-
     // enable / disable colors in the output (reporters and logs)
     colors: true,
 
-
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_ERROR,
-
+    logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
+    autoWatch: false,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['PhantomJS_mobile', 'PhantomJS_desktop'],
-
 
     // Custom browser launchers from phantom-karma-launcher for mobile / desktop
     customLaunchers: {
@@ -96,9 +83,8 @@ module.exports = function(config) {
       }
     },
 
-
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: true
   });
 };

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -22,6 +22,7 @@ require.config({
     modernizr: 'vendor/assets/modernizr/modernizr',
     mediaQueries: 'assets/js/lib/mediaQueries',
     componentLoader: 'assets/js/lib/componentLoader',
+    BackToTop: 'assets/js/components/BackToTop',
     Collapsable: 'assets/js/components/Collapsable',
     CollapsableMobile: 'assets/js/components/CollapsableMobile',
     ConfirmableForm: 'assets/js/components/ConfirmableForm',

--- a/spec/js/tests/BackToTop_spec.js
+++ b/spec/js/tests/BackToTop_spec.js
@@ -1,0 +1,83 @@
+describe('Back to Top link', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    requirejs(
+        ['jquery', 'BackToTop'],
+        function($, BackToTop) {
+          self.$html = $(window.__html__['spec/js/fixtures/BackToTop.html']);
+          self.component = self.$html.find('[data-dough-component="BackToTop"]');
+          self.backToTop = new BackToTop(self.component);
+          self.triggerPoint = self.backToTop.config.triggerPoint;
+          self.showClass = self.backToTop.showClass;
+          self.component.height(4000);
+
+          self.backToTop.init();
+          self.back_to_top_link = self.$html.find('.back_to_top__link');
+
+          done();
+        }, done);
+  });
+
+  afterEach(function() {
+    this.$html.remove();
+  });
+
+  describe('Set up link', function() {
+    it('Adds the link to the DOM', function() {
+      expect(this.back_to_top_link.length).to.equal(1);
+    });
+  });
+
+  describe('Set up footer', function() {
+    it('Adds extra space to footer', function() {
+      expect(this.$html.find('.l-footer-secondary')).to.have.class('back_to_top__spacer');
+    });
+  });
+
+  describe('Tests link activated state', function() {
+    beforeEach(function() {
+      this.stub = sinon.stub(this.backToTop, '_getScrollAmount');
+    });
+
+    afterEach(function() {
+      this.stub.restore();
+    });
+
+    it('Does not display link when user has scrolled up to trigger point in all views', function() {
+      // simulate scrolling to less than trigger point
+      this.stub.returns(this.triggerPoint - 1);
+      $(window).trigger('scroll');
+
+      expect(this.back_to_top_link).to.not.have.class(this.showClass);
+    });
+
+    it('Displays link when user has scrolled to trigger point in mobile view only', function() {
+      // simulate scrolling to trigger point
+      this.stub.returns(this.triggerPoint);
+      $(window).trigger('scroll');
+
+      if (this.backToTop.atSmallViewport) {
+        expect(this.back_to_top_link).to.have.class(this.showClass);
+      } else {
+        expect(this.back_to_top_link).to.not.have.class(this.showClass);
+      }
+    });
+  });
+
+  describe('Tests link behaviour when activated', function() {
+    beforeEach(function() {
+      this.back_to_top_link.trigger('click');
+    });
+
+    it('Returns user to top of page when clicked', function() {
+      expect($(window).scrollTop()).to.equal(0);
+    });
+
+    it('Hides link when clicked', function() {
+      expect(this.back_to_top_link).to.not.have.class(this.showClass);
+    });
+  });
+});

--- a/spec/js/tests/ConfirmableForm_spec.js
+++ b/spec/js/tests/ConfirmableForm_spec.js
@@ -41,7 +41,7 @@ describe('confirmation form', function () {
     it('blocks submission if the user does not confirm', function() {
       var calledWith,
           stubFn = function(arg) { calledWith = arg; return true; },
-          confirm = sandbox.stub(window, 'confirm', stubFn);
+          confirm = sandbox.stub(window, 'confirm').callsFake(stubFn);
       this.$input.click();
       expect(calledWith).to.eq('The message');
     });

--- a/spec/js/tests/TabSelector_spec.js
+++ b/spec/js/tests/TabSelector_spec.js
@@ -142,7 +142,7 @@ describe('Tab selector', function() {
 
     it('closes the menu if the viewport is resized to small', function() {
       this.$triggers.last().click();
-      sinon.stub(this.TabSelector.prototype, '_haveTriggersWrapped', function() {
+      sinon.stub(this.TabSelector.prototype, '_haveTriggersWrapped').callsFake(function() {
         return true;
       });
       this.eventsWithPromises.publish('mediaquery:resize', {

--- a/spec/js/tests/utilities_spec.js
+++ b/spec/js/tests/utilities_spec.js
@@ -157,7 +157,7 @@ describe('utilities', function() {
     });
 
     it('should not attempt to call console if browser does not support it', function() {
-      var stubDoesConsoleExist = sinon.stub(this.mod, 'doesConsoleExist', function() {
+      var stubDoesConsoleExist = sinon.stub(this.mod, 'doesConsoleExist').callsFake(function() {
         return false;
       });
 


### PR DESCRIPTION
[TP7313](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/8733&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/7317)

TECH DEBT: 

When implementing [TP7225](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/7317&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/7225) we did not complete the Unit Tests for that work, which was to add a link on article pages in the mobile view to allow users to scroll back to the top of the page.
 
This ticket adds these tests that check that:
- the link element has been added to the DOM
- the footer has the required extra space to display this
- the link is displayed when the user has scrolled to the predetermined point
- the user is returned to the top of the page when the link is activated
