### PR TITLE
[DEV APPROVED] 8781 karma update deprecated methods

### DIFF
--- a/spec/js/tests/ConfirmableForm_spec.js
+++ b/spec/js/tests/ConfirmableForm_spec.js
@@ -41,7 +41,7 @@ describe('confirmation form', function () {
     it('blocks submission if the user does not confirm', function() {
       var calledWith,
           stubFn = function(arg) { calledWith = arg; return true; },
-          confirm = sandbox.stub(window, 'confirm', stubFn);
+          confirm = sandbox.stub(window, 'confirm').callsFake(stubFn);
       this.$input.click();
       expect(calledWith).to.eq('The message');
     });

--- a/spec/js/tests/TabSelector_spec.js
+++ b/spec/js/tests/TabSelector_spec.js
@@ -142,7 +142,7 @@ describe('Tab selector', function() {
 
     it('closes the menu if the viewport is resized to small', function() {
       this.$triggers.last().click();
-      sinon.stub(this.TabSelector.prototype, '_haveTriggersWrapped', function() {
+      sinon.stub(this.TabSelector.prototype, '_haveTriggersWrapped').callsFake(function() {
         return true;
       });
       this.eventsWithPromises.publish('mediaquery:resize', {

--- a/spec/js/tests/utilities_spec.js
+++ b/spec/js/tests/utilities_spec.js
@@ -157,7 +157,7 @@ describe('utilities', function() {
     });
 
     it('should not attempt to call console if browser does not support it', function() {
-      var stubDoesConsoleExist = sinon.stub(this.mod, 'doesConsoleExist', function() {
+      var stubDoesConsoleExist = sinon.stub(this.mod, 'doesConsoleExist').callsFake(function() {
         return false;
       });
 


### PR DESCRIPTION
[TP8781](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=userstory/8781)

There are some Karma tests in Dough that are using soon-to-be-deprecated methods. The following warnings thrown by running the tests: 
- sandbox.stub(obj, 'meth', val) is deprecated and will be removed from the public API in a future version of sinon. Use sandbox.stub(obj, 'meth').callsFake(fn) instead in order to stub a function.
- sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon. Use stub(obj, 'meth').callsFake(fn)

This PR updates these so that they will not break. 
 
The tests affected are: 
- ConfirmableForm_spec.js
- TabSelector_spec.js
- utilities_spec.js
