### PR TITLE
Update rails for fincap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ notifications:
   email: false
 install:
   - bundle install
-  - npm install bower
+  - npm install -g bower
   - npm install
-  - bundle exec bower update
+  - bower update

--- a/dough-ruby.gemspec
+++ b/dough-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     ['LICENSE', 'Rakefile', 'README.md', 'bower.json', '.jscsrc', '.jshintrc']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '>= 3.2', '< 5'
+  s.add_dependency 'rails', '>= 3.2', '<= 5.0.6'
   s.add_dependency 'sass-rails'
   s.add_dependency 'activesupport'
   s.add_dependency 'activemodel'

--- a/lib/dough/forms/builders/validation.rb
+++ b/lib/dough/forms/builders/validation.rb
@@ -34,11 +34,11 @@ module Dough
           )
         end
 
-        private
-
         def view_renderer
           ActionView::Renderer.new(lookup_context)
         end
+
+        private
 
         def error_models
           @error_models ||= [object]

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.26.3'
+  VERSION = '5.27.0'
 end

--- a/spec/lib/dough/forms/builders/validation_spec.rb
+++ b/spec/lib/dough/forms/builders/validation_spec.rb
@@ -22,6 +22,12 @@ describe Dough::Forms::Builders::Validation do
 
   subject(:form_builder) { described_class.new(:model, model, {}, {}) }
 
+  describe '#view_renderer' do
+    it 'do not raise exception' do
+      expect { form_builder.view_renderer }.to_not raise_exception
+    end
+  end
+
   describe '#error_count' do
     it 'returns number of errors' do
       expect(subject.error_count).to eql(5)


### PR DESCRIPTION
**No TP cards** but it is blocking the fincap since this [PR](https://github.com/moneyadviceservice/fin_cap/pull/39)

This gem was added to Fincap [here](https://github.com/moneyadviceservice/fin_cap/pull/39/files#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R8) but it was raising the errors that Dough was not compatible with Rails 5.

So this PR addresses the Rails 5 update and fix for it which is explained on the commit message.
