### PR TITLE
[DEV APPROVED] Adding medium and large breakpoints in mediaQueries

### DIFF
--- a/assets/js/lib/mediaQueries.js
+++ b/assets/js/lib/mediaQueries.js
@@ -101,6 +101,12 @@ define(['jquery', 'eventsWithPromises', 'featureDetect', 'jqueryThrottleDebounce
      */
     atSmallViewport: function() {
       return ($.inArray(getSize(), ['mq-xs', 'mq-s']) > -1);
+    },
+    atMediumViewport: function() {
+      return ($.inArray(getSize(), ['mq-m']) > -1);
+    },
+    atLargeViewport: function() {
+      return ($.inArray(getSize(), ['mq-l', 'mq-xl']) > -1);
     }
 
   };

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.27.0'
+  VERSION = '5.28.0'
 end


### PR DESCRIPTION
This PR adds in medium and large breakpoint functions to mediaQueries.

This is being done as part of [TP9480](https://moneyadviceservice.tpondemand.com/entity/9480-js-to-resize-fee-blocks-when) as the JS breakpoint support needs to be higher