### PR TITLE
9847 modify dough component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bower.json
 docs/js
 .publish/
 .sass-cache/
+*.iml

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -13,7 +13,8 @@
 define(['utilities'], function(utilities) {
   'use strict';
 
-  var DoughBaseComponent;
+  var DoughBaseComponent,
+  indexCounter = 0;
 
   /**
    * @constructor
@@ -30,10 +31,10 @@ define(['utilities'], function(utilities) {
     if (!$el || !$el.length) {
       throw new Error('Element not supplied to DoughBaseComponent constructor');
     }
-
     this.config = $.extend({}, defaultConfig || {}, config || {});
     this.setElement($el);
     this._setComponentName(this.constructor.componentName);
+    this.__index = this._getNextDoughComponentID();
 
     /*
      Populate this array with the data attributes this module will use.
@@ -187,6 +188,10 @@ define(['utilities'], function(utilities) {
     if (warning) {
       utilities.log(warning, 'warn');
     }
+  };
+
+  DoughBaseComponent.prototype._getNextDoughComponentID = function () {
+    return (++indexCounter).toString();
   };
 
   return DoughBaseComponent;

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -199,7 +199,7 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
     }
   };
 
-  DoughBaseComponent.prototype._getNextDoughComponentID = function () {
+  DoughBaseComponent.prototype._getNextDoughComponentID = function() {
     return (++indexCounter).toString();
   };
 

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -34,7 +34,7 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
     this.config = $.extend({}, defaultConfig || {}, config || {});
     this.setElement($el);
     this._setComponentName(this.constructor.componentName);
-    this.__index = this._getNextDoughComponentID();
+    this.__id = this._getNextDoughComponentID();
 
     /*
      Populate this array with the data attributes this module will use.
@@ -154,7 +154,7 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
    */
   DoughBaseComponent.prototype._initialisedSuccess = function(initialised) {
     this.$el.attr('data-dough-' + this.componentAttributeName + '-initialised', 'yes');
-    this.$el.attr('data-dough-' + this.componentAttributeName + '-index', this.__index);
+    this.$el.attr('data-dough-' + this.componentAttributeName + '-id', this.__id);
     this.$el.trigger(DoughEventConstants.InitialisedSuccess,
       {
         'instance': this

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -157,7 +157,7 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
     this.$el.attr('data-dough-' + this.componentAttributeName + '-index', this.__index);
     this.$el.trigger(DoughEventConstants.InitialisedSuccess,
       {
-        'instance': this,
+        'instance': this
       });
     initialised && initialised.resolve(this.componentName);
   };
@@ -169,7 +169,7 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
   DoughBaseComponent.prototype._initialisedFailure = function(initialised) {
     this.$el.trigger(DoughEventConstants.InitialisedFailure,
       {
-        'instance': this,
+        'instance': this
       });
     initialised && initialised.reject(this.componentName);
   };

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -154,6 +154,7 @@ define(['utilities'], function(utilities) {
    */
   DoughBaseComponent.prototype._initialisedSuccess = function(initialised) {
     this.$el.attr('data-dough-' + this.componentAttributeName + '-initialised', 'yes');
+    this.$el.attr('data-dough-' + this.componentAttributeName + '-index', this.__index);
     initialised && initialised.resolve(this.componentName);
   };
 

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -167,6 +167,10 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
    * promise will be fed back to the component loader
    */
   DoughBaseComponent.prototype._initialisedFailure = function(initialised) {
+    this.$el.trigger(DoughEventConstants.InitialisedFailure,
+      {
+        'instance': this,
+      });
     initialised && initialised.reject(this.componentName);
   };
 

--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -10,7 +10,7 @@
  * @module DoughBaseComponent
  * @returns {class} DoughBaseComponent
  */
-define(['utilities'], function(utilities) {
+define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConstants) {
   'use strict';
 
   var DoughBaseComponent,
@@ -155,6 +155,10 @@ define(['utilities'], function(utilities) {
   DoughBaseComponent.prototype._initialisedSuccess = function(initialised) {
     this.$el.attr('data-dough-' + this.componentAttributeName + '-initialised', 'yes');
     this.$el.attr('data-dough-' + this.componentAttributeName + '-index', this.__index);
+    this.$el.trigger(DoughEventConstants.InitialisedSuccess,
+      {
+        'instance': this,
+      });
     initialised && initialised.resolve(this.componentName);
   };
 

--- a/assets/js/constants/DoughEventConstants.js
+++ b/assets/js/constants/DoughEventConstants.js
@@ -1,0 +1,12 @@
+define([],
+function () {
+  'use strict';
+  var DoughEventConstants = {};
+
+  DoughEventConstants.InitialisedSuccess = "INITIALISE-SUCCESS.DoughBaseEvent";
+  DoughEventConstants.InitialisedFailure = "INITIALISE-FAILURE.DoughBaseEvent";
+
+  DoughEventConstants.ComponentsComplete = "COMPONENTS_COMPLETE.DoughBaseEvent";
+
+  return DoughEventConstants;
+});

--- a/assets/js/constants/DoughEventConstants.js
+++ b/assets/js/constants/DoughEventConstants.js
@@ -1,5 +1,5 @@
 define([],
-function () {
+function() {
   'use strict';
   var DoughEventConstants = {};
 

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -18,6 +18,7 @@ require.config({
 
   paths: {
     DoughBaseComponent: 'assets/js/components/DoughBaseComponent',
+    DoughEventConstants: 'assets/js/constants/DoughEventConstants',
     featureDetect: 'assets/js/lib/featureDetect',
     modernizr: 'vendor/assets/modernizr/modernizr',
     mediaQueries: 'assets/js/lib/mediaQueries',

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -108,6 +108,16 @@ describe('DoughBaseComponent', function() {
           .to
           .match(/[0-9]+/);
       });
+
+      it('should trigger a successful event upon initialisation', function() {
+        var doughBaseComponent = new this.DoughBaseComponent(this.component);
+
+        doughBaseComponent.$el.on('INITIALISE-SUCCESS.DoughBaseEvent', function(event) {
+          expect(event.type).to.eq('INITIALISE-SUCCESS');
+        });
+        doughBaseComponent._initialisedSuccess(initialised);
+
+      });
     });
 
     describe('failed', function() {

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -98,6 +98,16 @@ describe('DoughBaseComponent', function() {
 
         expect(doughBaseComponent.$el).to.have.attr('data-dough-dough-base-component-initialised', 'yes');
       });
+
+      it('should stamp an index attribute on the component element', function() {
+        var doughBaseComponent = new this.DoughBaseComponent(this.component);
+
+        doughBaseComponent._initialisedSuccess(initialised);
+
+        expect(doughBaseComponent.$el.attr('data-dough-dough-base-component-index'))
+          .to
+          .match(/[0-9]+/);
+      });
     });
 
     describe('failed', function() {

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -110,13 +110,13 @@ describe('DoughBaseComponent', function() {
       });
 
       it('should trigger a successful event upon initialisation', function() {
-        var doughBaseComponent = new this.DoughBaseComponent(this.component);
+        var doughBaseComponent = new this.DoughBaseComponent(this.component),
+            spy = sandbox.spy();
 
-        doughBaseComponent.$el.on('INITIALISE-SUCCESS.DoughBaseEvent', function(event) {
-          expect(event.type).to.eq('INITIALISE-SUCCESS');
-        });
+        doughBaseComponent.$el.on('INITIALISE-SUCCESS.DoughBaseEvent', spy);
         doughBaseComponent._initialisedSuccess(initialised);
 
+        expect(spy.called).to.be.true;
       });
     });
 
@@ -131,12 +131,13 @@ describe('DoughBaseComponent', function() {
       });
 
       it('should trigger a failed event', function() {
-        var doughBaseComponent = new this.DoughBaseComponent(this.component);
+        var doughBaseComponent = new this.DoughBaseComponent(this.component),
+            spy = sandbox.spy();
 
-        doughBaseComponent.$el.on('INITIALISE-FAILURE.DoughBaseEvent', function(event) {
-          expect(event.type).to.eq('INITIALISE-FAILURE');
-        });
+        doughBaseComponent.$el.on('INITIALISE-FAILURE.DoughBaseEvent', spy);
         doughBaseComponent._initialisedFailure(initialised);
+
+        expect(spy.called).to.be.true;
 
       });
     });

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -67,6 +67,12 @@ describe('DoughBaseComponent', function() {
         foo: 'bar'
       });
     });
+
+    it('should create a unique id for each component', function() {
+      var doughBaseComponent = new this.DoughBaseComponent(this.component);
+
+      expect(doughBaseComponent.__index).to.match(/[0-9]+/);
+    });
   });
 
   describe('initialisation', function() {

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -129,6 +129,16 @@ describe('DoughBaseComponent', function() {
 
         expect(spy.called).to.be.true;
       });
+
+      it('should trigger a failed event', function() {
+        var doughBaseComponent = new this.DoughBaseComponent(this.component);
+
+        doughBaseComponent.$el.on('INITIALISE-FAILURE.DoughBaseEvent', function(event) {
+          expect(event.type).to.eq('INITIALISE-FAILURE');
+        });
+        doughBaseComponent._initialisedFailure(initialised);
+
+      });
     });
   });
 

--- a/spec/js/tests/DoughBaseComponent_spec.js
+++ b/spec/js/tests/DoughBaseComponent_spec.js
@@ -71,7 +71,7 @@ describe('DoughBaseComponent', function() {
     it('should create a unique id for each component', function() {
       var doughBaseComponent = new this.DoughBaseComponent(this.component);
 
-      expect(doughBaseComponent.__index).to.match(/[0-9]+/);
+      expect(doughBaseComponent.__id).to.match(/[0-9]+/);
     });
   });
 


### PR DESCRIPTION
https://moneyadviceservice.tpondemand.com/entity/9847-modify-doughbasecomponent

This is one piece of work being done to update the Dough gem.

Adding an index attribute for each DoughBase Component makes it a lot harder for these instances to be referenced and called. 
The other part of the work in this ticket was to publish events on the success/failure of component initalization. 

We've started off with having event strings being stored in once central location as constants. We had a long discussion over the best way of implementing these, firstly for performance (with minification), secondly as to the best place for each of these events to be stored - along with the best convention to use for these. 

Please feel free to comment on this approach and if you feel like there may be a nicer solution