### PR TITLE
[DEV APPROVED] 9392 popup tip position

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -1,5 +1,5 @@
-define(['jquery', 'DoughBaseComponent'],
-  function($, DoughBaseComponent) {
+define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
+  function($, DoughBaseComponent, mediaQueries, utilities) {
   'use strict';
 
   var defaultConfig = {
@@ -20,6 +20,8 @@ define(['jquery', 'DoughBaseComponent'],
     this.$trigger = this.$el.find(this.config.selectors.trigger);
     this.$popup   = this.$el.find(this.config.selectors.popupContainer);
     this.$popupContent = this.$el.find(this.config.selectors.popupContent);
+    this.offset = 35;
+    this.debounceWait = 100;
 
     return this;
   };
@@ -29,22 +31,61 @@ define(['jquery', 'DoughBaseComponent'],
 
   PopupTip.prototype._addEvents = function() {
     var $closeBtn = this.$el.find(this.config.selectors.popupClose);
+    var resizeProxy = $.proxy(this._resize, this);
 
-    this.$trigger.click($.proxy(this.showPopupTip, this));
-    $closeBtn.click($.proxy(this.hidePopupTip, this));
+    this.$trigger.click($.proxy(this._showPopupTip, this));
+    $closeBtn.click($.proxy(this._hidePopupTip, this));
+    $(window).on('resize', utilities.debounce(resizeProxy, this.debounceWait));
   };
 
-  PopupTip.prototype.showPopupTip = function() {
-    this.$popup.removeClass(this.config.selectors.inactiveClass);
-    this.$popup.addClass(this.config.selectors.activeClass);
+  PopupTip.prototype._showPopupTip = function(e) {
+    this.$popup
+      .removeClass(this.config.selectors.inactiveClass)
+      .addClass(this.config.selectors.activeClass);
     this.$popupContent.attr('tabindex', -1).focus();
+
+    this._positionPopup(this.$popup, $(e.target));
   };
 
-  PopupTip.prototype.hidePopupTip = function() {
+  PopupTip.prototype._resize = function() {
+    if (this.$el.find('.is-active').length > 0) {
+      var $index = this.$el.find('.is-active');
+      var $trigger = $index.parents('[data-dough-component]').find('[data-dough-popup-trigger]');
+
+      this._positionPopup($index, $trigger);
+    }
+  };
+
+  PopupTip.prototype._positionPopup = function($index, $trigger) {
+    if (this.atSmallViewport()) {
+      $index.css('top', $trigger.position().top + this.offset);
+      $index.css('left', 0);
+      $index.css('width', '100%');
+    } else {
+      $index.css('top', $trigger.position().top + this.offset);
+
+      // is icon less or more than 50% across page width
+      if ($trigger.position().left - ($trigger.width() / 2) < ($(window).width() / 2)) {
+        $index.css('left', $trigger.position().left + this.offset);
+      } else {
+        $index.css('left', $trigger.position().left - $index.width() - this.offset);
+      }
+    }
+  };
+
+  PopupTip.prototype._hidePopupTip = function() {
     this.$popup.addClass(this.config.selectors.inactiveClass);
     this.$popup.removeClass(this.config.selectors.activeClass);
     this.$trigger.focus();
   };
+
+  PopupTip.prototype.atSmallViewport = function() {
+    if (mediaQueries.atSmallViewport()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 
   PopupTip.prototype.init = function(initialised) {
     this._addEvents();

--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -1,3 +1,7 @@
+*[data-dough-component="PopupTip"] {
+  position: relative;
+}
+
 .popup-tip__button {
   display: none;
   background-color: transparent;
@@ -6,13 +10,16 @@
   font-style: italic;
   position: relative;
 
+  & > * {
+    pointer-events: none;
+  }
+
   .js & {
     display: inline;
   }
 }
 
 .popup-tip__container {
-  
   .js & {
     padding: $baseline-unit*2;
     display: none;
@@ -20,7 +27,7 @@
     background-color: $color-white;
     z-index: 1;
     position: absolute;
-    left: $baseline-unit;
+    width: 100%;
 
     &.is-inactive {
       display: none;
@@ -28,6 +35,10 @@
 
     &.is-active {
       display: block;
+
+      @include respond-to($mq-m) {
+        top: 0;
+      }
     }
 
     @include respond-to($mq-m) {

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.28.0'
+  VERSION = '5.29.0'
 end

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "karma-chrome-launcher": "^0.1.2",
     "karma-cli": "^1.0.1",
     "karma-coverage": "^0.2.4",
+    "karma-fixture": "^0.2.6",
     "karma-html2js-preprocessor": "^1.1.0",
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^1.3.0",

--- a/spec/js/fixtures/PopupTip.html
+++ b/spec/js/fixtures/PopupTip.html
@@ -1,12 +1,76 @@
-<div data-dough-component="PopupTip">
-  <button data-dough-popup-trigger type="button"></button>
-  <div data-dough-popup-container>
-    <p data-dough-popup-content>Content</p>
-    <button data-dough-popup-close type="button">
-      <span aria-hidden="true">X</span>
-      <span class="visually-hidden">
-        Close
-      </span>
-    </button>
+<div>
+  <div id="PopupTip_shortText" data-dough-component="PopupTip">
+    <p><span id="explanatoryText_1">Some text</span><button data-dough-popup-trigger type="button" id="trigger_1"></button></p>
+    <div data-dough-popup-container id="container_1">
+      <p data-dough-popup-content>Content</p>
+      <button data-dough-popup-close type="button">
+        <span aria-hidden="true">X</span>
+        <span class="visually-hidden">
+          Close
+        </span>
+      </button>
+    </div>
   </div>
+
+  <div id="PopupTip_longText" data-dough-component="PopupTip">
+    <p><span id="explanatoryText_2">Some considerably longer text</span><button data-dough-popup-trigger type="button" id="trigger_2"></button></p>
+    <div data-dough-popup-container id="container_2">
+      <p data-dough-popup-content>Content</p>
+      <button data-dough-popup-close type="button">
+        <span aria-hidden="true">X</span>
+        <span class="visually-hidden">
+          Close
+        </span>
+      </button>
+    </div>
+  </div>
+
+  <div id="PopupTip_mobile" data-dough-component="PopupTip">
+    <p><span>Some text whose length is irrelevant</span><button data-dough-popup-trigger type="button" id="trigger_3"></button></p>
+    <div data-dough-popup-container id="container_3">
+      <p data-dough-popup-content>Content</p>
+      <button data-dough-popup-close type="button">
+        <span aria-hidden="true">X</span>
+        <span class="visually-hidden">
+          Close
+        </span>
+      </button>
+    </div>
+  </div>
+
+  <style>
+      #PopupTip_shortText, #PopupTip_longText, #PopupTip_mobile {
+        position: relative;
+      }
+
+      #trigger_1, #trigger_2, #trigger_3 {
+        width: 25px;
+        height: 25px;
+      }
+
+      #explanatoryText_1, #explanatoryText_2 {
+        display: inline-block;
+      }
+
+      #explanatoryText_1 {
+        width: 100px;
+      }
+
+      #explanatoryText_2 {
+        width: 700px;
+      }
+
+      #container_1, #container_2, #container_3 {
+        position: absolute;
+      }
+
+      #container_1, #container_2 {
+        top: 0;
+        width: 300px;
+      }
+
+      #container_3 {
+        width: 100%;
+      }
+  </style>
 </div>

--- a/spec/js/karma.conf.js
+++ b/spec/js/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['requirejs', 'mocha', 'chai-jquery', 'chai', 'sinon', 'jquery-1.11.0'],
+    frameworks: ['requirejs', 'mocha', 'chai-jquery', 'chai', 'sinon', 'jquery-1.11.0', 'fixture'],
 
     // list of files / patterns to load in the browser
     files: [

--- a/spec/js/tests/PopupTip_spec.js
+++ b/spec/js/tests/PopupTip_spec.js
@@ -1,8 +1,5 @@
-describe.only('Displays Popup Tooltip', function() {
+describe('Displays Popup Tooltip', function() {
   'use strict';
-
-  // var webPage = require('webpage');
-  // console.log(webPage);
 
   var activeClass   = 'is-active',
       inactiveClass = 'is-inactive';
@@ -10,56 +7,148 @@ describe.only('Displays Popup Tooltip', function() {
   beforeEach(function(done) {
     var self = this;
 
+    fixture.setBase('spec/js/fixtures');
+
     requirejs(
       ['jquery', 'PopupTip'], function($, PopupTip) {
-        self.$html    = $(window.__html__['spec/js/fixtures/PopupTip.html']).appendTo('body');
-        self.PopupTip = PopupTip;
-        // self.webPage = require('webpage');
+        fixture.load('PopupTip.html');
+
+        self.clock = sinon.useFakeTimers();
+        self.$popupTip = $(fixture.el).find('[data-dough-component="PopupTip"]');
+        self.obj = new PopupTip(self.$popupTip);
+        self.obj.init();
+        self.offset = self.obj.offset;
+        self.$container = self.$popupTip.find('[data-dough-popup-container]');
+        self.$close = self.$popupTip.find('[data-dough-popup-close]');
+        self.$trigger_1 = $(document).find('#trigger_1');
+        self.$container_1 = $(document).find('#container_1');
+        self.$trigger_2 = $(document).find('#trigger_2');
+        self.$container_2 = $(document).find('#container_2');
+        self.$trigger_3 = $(document).find('#trigger_3');
+        self.$container_3 = $(document).find('#container_3');
+        self.$component_mobile = $(document).find('#PopupTip_mobile');
 
         done();
       }, done);
   });
 
   afterEach(function() {
-    this.$html.remove();
+    fixture.cleanup();
+    this.clock.restore();
   });
 
   describe('Default behaviour', function() {
-
-    beforeEach(function(done) {
-      this.$html      = $(window.__html__['spec/js/fixtures/PopupTip.html']);
-      this.$trigger   = this.$html.find('[data-dough-popup-trigger]');
-      this.$container = this.$html.find('[data-dough-popup-container]');
-      this.$close     = this.$html.find('[data-dough-popup-close]');
-      this.popupTip   = new this.PopupTip(this.$html);
-      this.popupTip.init();
-
-      // this.page = this.webPage.create();
-
-      // console.log(page);
-
-      done();
-    });
-
     it('hides the popup content on load', function() {
       expect(this.$container).to.not.have.class(activeClass);
     });
+  });
 
-    it('displays the popup in the correct position on trigger click', function() {
-      this.$trigger.click();
+  describe('Dynamic behaviour', function() {
+    beforeEach(function() {
+      this.$container
+        .removeClass(activeClass)
+        .addClass(inactiveClass);
+    });
+
+    it('displays the popup on trigger click', function() {
+      this.$trigger_1.click();
       expect(this.$container).to.have.class(activeClass);
+    });
 
-      var trigger = this.$trigger[0];
-      console.log(trigger.getBoundingClientRect());
-      console.log($(window).width());
-      // console.log($(trigger).width());
+    it('aligns the popup with trigger on LHS/top when icon position < 50% viewport width on desktop', function() {
+      var trigger = this.$trigger_1[0];
+      var container = this.$container_1[0];
+
+      trigger.click();
+
+      if (!this.obj.atSmallViewport()) {
+        expect(container.getBoundingClientRect().left).to.equal(trigger.getBoundingClientRect().left + this.offset);
+        expect(container.getBoundingClientRect().top).to.equal(trigger.getBoundingClientRect().top + this.offset);
+      }
+    });
+
+    it('aligns the popup with trigger on RHS/top when icon position > 50% viewport width on desktop', function() {
+      var trigger = this.$trigger_2[0];
+      var container = this.$container_2[0];
+
+      trigger.click();
+
+      if (!this.obj.atSmallViewport()) {
+        expect(container.getBoundingClientRect().left).to.equal(trigger.getBoundingClientRect().left - container.getBoundingClientRect().width - this.offset);
+        expect(container.getBoundingClientRect().top).to.equal(trigger.getBoundingClientRect().top + this.offset);
+      }
+    });
+
+    it('displays the popup full width on mobile', function() {
+      var trigger = this.$trigger_3[0];
+      var container = this.$container_3[0];
+      var component = this.$component_mobile[0];
+
+      trigger.click();
+
+      if (this.obj.atSmallViewport()) {
+        expect(container.getBoundingClientRect().left).to.equal(component.getBoundingClientRect().left);
+        expect(container.getBoundingClientRect().width).to.equal(component.getBoundingClientRect().width);
+      }
+    });
+
+    it('sets the correct position of an open popup when the viewport resizes when icon position < 50% viewport width on desktop', function() {
+      var trigger = this.$trigger_1[0];
+      var container = this.$container_1[0];
+
+      $(container)
+        .removeClass(inactiveClass)
+        .addClass(activeClass);
+
+      $(window).resize();
+
+      this.clock.tick(this.obj.debounceWait);
+
+      if (!this.obj.atSmallViewport()) {
+        expect(container.getBoundingClientRect().left).to.equal(trigger.getBoundingClientRect().left + this.offset);
+        expect(container.getBoundingClientRect().top).to.equal(trigger.getBoundingClientRect().top + this.offset);
+      }
+    });
+
+    it('sets the correct position of an open popup when the viewport resizes when icon position > 50% viewport width on desktop', function() {
+      var trigger = this.$trigger_2[0];
+      var container = this.$container_2[0];
+
+      $(container)
+        .removeClass(inactiveClass)
+        .addClass(activeClass);
+
+      $(window).resize();
+
+      this.clock.tick(this.obj.debounceWait);
+
+      if (!this.obj.atSmallViewport()) {
+        expect(container.getBoundingClientRect().left).to.equal(trigger.getBoundingClientRect().left - container.getBoundingClientRect().width - this.offset);
+        expect(container.getBoundingClientRect().top).to.equal(trigger.getBoundingClientRect().top + this.offset);
+      }
+    });
+
+    it('sets the correct position of an open popup when the viewport resizes on mobile', function() {
+      var container = this.$container_3[0];
+      var component = this.$component_mobile[0];
+
+      $(container)
+        .removeClass(inactiveClass)
+        .addClass(activeClass);
+
+      $(window).resize();
+
+      this.clock.tick(this.obj.debounceWait);
+
+      if (this.obj.atSmallViewport()) {
+        expect(container.getBoundingClientRect().left).to.equal(component.getBoundingClientRect().left);
+        expect(container.getBoundingClientRect().width).to.equal(component.getBoundingClientRect().width);
+      }
     });
 
     it('closes the popup on close button click', function() {
       this.$close.click();
       expect(this.$container).to.have.class(inactiveClass);
     });
-
   });
-
 });

--- a/spec/js/tests/PopupTip_spec.js
+++ b/spec/js/tests/PopupTip_spec.js
@@ -1,5 +1,8 @@
-describe('Displays Popup Tooltip', function() {
+describe.only('Displays Popup Tooltip', function() {
   'use strict';
+
+  // var webPage = require('webpage');
+  // console.log(webPage);
 
   var activeClass   = 'is-active',
       inactiveClass = 'is-inactive';
@@ -11,7 +14,8 @@ describe('Displays Popup Tooltip', function() {
       ['jquery', 'PopupTip'], function($, PopupTip) {
         self.$html    = $(window.__html__['spec/js/fixtures/PopupTip.html']).appendTo('body');
         self.PopupTip = PopupTip;
-        
+        // self.webPage = require('webpage');
+
         done();
       }, done);
   });
@@ -30,16 +34,25 @@ describe('Displays Popup Tooltip', function() {
       this.popupTip   = new this.PopupTip(this.$html);
       this.popupTip.init();
 
+      // this.page = this.webPage.create();
+
+      // console.log(page);
+
       done();
     });
 
     it('hides the popup content on load', function() {
-      expect(this.$container).to.not.have.class(activeClass);    
+      expect(this.$container).to.not.have.class(activeClass);
     });
 
-    it('displays the popup on trigger click', function() {
+    it('displays the popup in the correct position on trigger click', function() {
       this.$trigger.click();
-      expect(this.$container).to.have.class(activeClass); 
+      expect(this.$container).to.have.class(activeClass);
+
+      var trigger = this.$trigger[0];
+      console.log(trigger.getBoundingClientRect());
+      console.log($(window).width());
+      // console.log($(trigger).width());
     });
 
     it('closes the popup on close button click', function() {


### PR DESCRIPTION
[TP9392](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/9392/silent)

The Dough tooltip component currently always displays in the same position, meaning that in some circumstances it appears relatively distant from the icon that triggers it. This is particularly noticeable on the Debt Advice Locator tool and creates a confusing user experience (as below). 

![image](https://user-images.githubusercontent.com/6080548/48628587-7964d500-e9af-11e8-8de8-e9823b24a2a9.png)

The work in this PR sets the position of the popup to be related to the trigger position (see below). This is aligned with a lateral variation depending on the trigger position relative to the centre of the page so that the popup will not display off-screen.

![image](https://user-images.githubusercontent.com/6080548/48628784-f132ff80-e9af-11e8-9266-4ba77f54c488.png)
