### PR TITLE
[DEV APPROVED] 9852 component loader

### DIFF
--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -17,7 +17,7 @@
  * @module componentLoader
  * @returns {Function} componentLoader
  */
-define(['jquery', 'rsvp', 'utilities'], function($, RSVP, utilities) {
+define(['jquery', 'rsvp', 'utilities', 'DoughEventConstants'], function($, RSVP, utilities, DoughEventConstants) {
 
   'use strict';
 
@@ -63,6 +63,7 @@ define(['jquery', 'rsvp', 'utilities'], function($, RSVP, utilities) {
       promises = RSVP.allSettled(initialisedList.promises);
       promises.then(function() {
         $('body').attr('data-dough-component-loader-all-loaded', 'yes');
+        $container.trigger(DoughEventConstants.ComponentsComplete);
       });
       return promises;
     },
@@ -185,6 +186,9 @@ define(['jquery', 'rsvp', 'utilities'], function($, RSVP, utilities) {
           try {
             instance.init && instance.init(initialisedList[i]);
           } catch (err) {
+            if (document.location.hostname.indexOf('localhost') >= 0) {
+              console.log(err);
+            }
             initialisedList[i].reject(err);
           }
           i++;

--- a/spec/js/tests/componentLoader_spec.js
+++ b/spec/js/tests/componentLoader_spec.js
@@ -9,9 +9,10 @@ describe('componentLoader', function() {
         range: true
       }
     };
-    requirejs(['componentLoader', 'utilities'], function(componentLoader, utilities) {
+    requirejs(['componentLoader', 'utilities', 'DoughEventConstants'], function(componentLoader, utilities, DoughEventConstants) {
       self.componentLoader = componentLoader;
       self.utilities = utilities;
+      self.doughEventConstants = DoughEventConstants;
       done();
     });
   });
@@ -80,6 +81,17 @@ describe('componentLoader', function() {
 
     it('should set a flag to indicate all components have been initialised', function() {
       expect($('body').is('[data-dough-component-loader-all-loaded="yes"]')).to.equal(true);
+    });
+
+    it('should fire a COMPONENTS_COMPLETE.DoughBaseEvent when all components have been initialised', function() {
+      var spy = sinon.spy();
+
+      this.$html.on('COMPONENTS_COMPLETE.DoughBaseEvent', spy);
+
+      this.componentLoader.init(this.$html, true).then(function() {
+        expect(spy.called).to.be.true;
+        done();
+      });
     });
 
     it('should keep track of all initialized components', function() {


### PR DESCRIPTION
Here we modify the componentLoader so it dispatches an Completion event for our code to hook into. We already have domReady and window.load events. This Component_Complete Dough Event will allow us to know when all the dough components are ready.

As part of this PR, we are also outputting any errors fired from the .init() fucntion that are trapped by the try...catch.