### PR TITLE
TP: 9886, Comment: Fixes positioning of popup on Car Cost Calculator

### DIFF
--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -1,4 +1,4 @@
-div[data-dough-component="PopupTip"] {
+*[data-dough-component="PopupTip"] {
   position: relative;
 }
 


### PR DESCRIPTION
[TP9886](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/9886)

When the popup tip component is applied to the Car Costs Calculator there is a problem with the way the positioning is applied. 

This is because the styles within Dough assume the containing element is a ```<div>``` where in practice it can be any element and in this instance is a ```<span>```. This work updates the style so that the parent can be any element.