### PR TITLE
[WIP] Workaround fix for the init() being invoked twice.

### DIFF
--- a/assets/js/components/DoughBaseComponent.js
+++ b/assets/js/components/DoughBaseComponent.js
@@ -153,6 +153,7 @@ define(['utilities', 'DoughEventConstants'], function(utilities, DoughEventConst
    * promise will be fed back to the component loader
    */
   DoughBaseComponent.prototype._initialisedSuccess = function(initialised) {
+    this.initialised = true;
     this.$el.attr('data-dough-' + this.componentAttributeName + '-initialised', 'yes');
     this.$el.attr('data-dough-' + this.componentAttributeName + '-id', this.__id);
     this.$el.trigger(DoughEventConstants.InitialisedSuccess,

--- a/assets/js/lib/componentLoader.js
+++ b/assets/js/lib/componentLoader.js
@@ -183,7 +183,7 @@ define(['jquery', 'rsvp', 'utilities'], function($, RSVP, utilities) {
       $.each(components, function(componentName, list) {
         $.each(list, function(idx, instance) {
           try {
-            instance.init && instance.init(initialisedList[i]);
+            instance.init && !instance.initialised && instance.init(initialisedList[i]);
           } catch (err) {
             initialisedList[i].reject(err);
           }


### PR DESCRIPTION
**Problem**
Whilst creating the AccountUIComponent and testing it's initialisation, I've noticed that the componentLoader creates the Components correctly (invokes Constructor function once) but the second loop seems to invoke the Components.init() function twice which could result in memory leaks.
 
The problem seems to be with the RSVP promise code, perhaps an issue of implementation? I'm not sure. Having a debugger statement in the allSettled block shows this is called twice and therefore the Components are initialised twice and therefore firing two INITIALISE-SUCCESS events for each deferred Component.

 
**Solution**
At the moment the workaround here is to set an initialised flag inside the DoughComponent which is set from this._initialisedSuccess() which is, by convention, to be called when the init() function has finished. We can then check for this flag in the componentLoader prior to calling init()...
 
_N.B. This is a workaround until we have the time to spend more time working out how the componentLoader is using Promises._