### PR TITLE
[DEV APPROVED] 10188 sdc icon misaligned

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -20,6 +20,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     this.$trigger = this.$el.find(this.config.selectors.trigger);
     this.$popup   = this.$el.find(this.config.selectors.popupContainer);
     this.$popupContent = this.$el.find(this.config.selectors.popupContent);
+    this.$container = this.$el.parent();
     this.offset = 35;
     this.debounceWait = 100;
 
@@ -57,10 +58,12 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
   };
 
   PopupTip.prototype._positionPopup = function($index, $trigger) {
+    this.$container.css('position', 'relative');
+    $index.css('width', this.$container.width());
+
     if (this.atSmallViewport()) {
       $index.css('top', $trigger.position().top + this.offset);
       $index.css('left', 0);
-      $index.css('width', '100%');
     } else {
       $index.css('top', $trigger.position().top + this.offset);
 

--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -1,7 +1,3 @@
-*[data-dough-component="PopupTip"] {
-  position: relative;
-}
-
 .popup-tip__button {
   display: none;
   background-color: transparent;

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.31.0'
+  VERSION = '5.32.0'
 end


### PR DESCRIPTION
[TP10188](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=bug/10188)

The recently updated i icons are displaying badly on the Stamp Duty Calculator tool. It is positioned wrongly and the width of the overlay is essentially zero. 

![image](https://user-images.githubusercontent.com/6080548/51979788-f6b7c600-2485-11e9-9a2e-57405aaad5a7.png)

This is caused by the component dynamically setting its position and size relative to the icon itself. 

The solution in this PR is to set these values relative to the parent of the icon that is a more reliable reference. 

![image](https://user-images.githubusercontent.com/6080548/51979657-9c1e6a00-2485-11e9-8417-aa3e02d427aa.png)
