### PR TITLE
10188 sdc icon misaligned position fix

### DIFF
--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -1,3 +1,7 @@
+*[data-dough-component="PopupTip"] {
+  position: relative;
+}
+
 .popup-tip__button {
   display: none;
   background-color: transparent;

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.32.0'
+  VERSION = '5.32.1'
 end


### PR DESCRIPTION
[TP10188](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=bug/10188)

As a result of testing a problem was found on the Debt Advice Locator tool. This PR is to restore a style removed in PR312 to fix this and redeploy for further testing. 