### PR TITLE
10188 sdc icon misaligned position fix

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -43,7 +43,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     this.$popup
       .removeClass(this.config.selectors.inactiveClass)
       .addClass(this.config.selectors.activeClass);
-    this.$popupContent.attr('tabindex', -1).focus();
+    this.$popupContent.focus();
 
     this._positionPopup(this.$popup, $(e.target));
   };

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.32.0'
+  VERSION = '5.32.1'
 end


### PR DESCRIPTION
[TP10188](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=bug/10188)

A further minor fix for the popup tip component. 

The tabindex property isn't required here and causes some odd scroll problems in some tools. As long as the focus moves into the overlay it allows the user to tab into the close button as required for accessibility reasons. 