### PR TITLE
Bump major version due to breaking change

### DIFF
--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.34.0'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
Bumping major version of dough. This is due to the previous PR introducing breaking changes to tools when bumped and extra steps need to be taken to upgrade to this version 