### PR TITLE
Use bundled base image for Jenkins

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,9 +1,9 @@
-FROM masdevtestregistry.azurecr.io/jenkins/ruby2.5.3:latest
-MAINTAINER development.team@moneyadviceservice.org.uk
+FROM masdevtestregistry.azurecr.io/jenkins/sfgb-bundle-2.5.3:latest
 
 RUN apt-get -qq update > /dev/null && \
   apt-get -qq dist-upgrade > /dev/null && \
   apt-get -qq clean  > /dev/null && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY . /var/tmp/app/
+WORKDIR /var/tmp/app/
+COPY . .

--- a/jenkins/build
+++ b/jenkins/build
@@ -10,23 +10,18 @@ fi
 
 export RAILS_ENV=production
 
-exit_code=0
-
 function run {
     declare -a build_command=("$@")
     echo ''
     echo "=== Running \`${build_command[*]}\`"
     if ! ${build_command[*]}; then
         echo "=== This build failed."
-        exit_code=1
+        exit 1
     fi
 }
 
-# (re)install node packages to local dir before tests run
-
+run bundle install
 run npm install
-run bundle install --quiet
 run gem build *.gemspec
 run gem inabox *.gem -g http://gems.dev.mas.local
 
-exit "$exit_code"

--- a/jenkins/test
+++ b/jenkins/test
@@ -12,8 +12,6 @@ export RAILS_ENV=test
 export BUNDLE_WITHOUT=development:build
 export PATH=./node_modules/.bin:$PATH
 
-exit_code=0
-
 function run {
     declare -a tests_command=("$@")
 
@@ -21,7 +19,7 @@ function run {
     echo "=== Running \`${tests_command[*]}\`"
     if ! ${tests_command[*]}; then
         echo "=== These tests failed."
-        exit_code=1
+        exit 1
     fi
 }
 
@@ -34,8 +32,8 @@ function info {
     fi
 }
 
+run bundle install
 run npm install
-run bundle install --quiet
 run bundle update brakeman --quiet
 run bower install --allow-root
 run bundle exec rspec
@@ -48,4 +46,3 @@ if [ -f /.dockerenv ]; then
   run bundle exec danger --dangerfile=jenkins/Dangerfile --verbose
 fi
 
-exit "$exit_code"


### PR DESCRIPTION
In an effort to increase efficiency and speed, we can now use a pre-bundled Docker image which includes all gems & dependancies.

Changes include;

- Use Pre-bundled base image in Jenkins
- Updates to test script