### PR TITLE
[DEV APPROVED] 9755 popup tip position fix

### DIFF
--- a/assets/js/components/PopupTip.js
+++ b/assets/js/components/PopupTip.js
@@ -3,16 +3,16 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
   'use strict';
 
   var defaultConfig = {
-        selectors: {
-          trigger:        '[data-dough-popup-trigger]',
-          popupContainer: '[data-dough-popup-container]',
-          popupContent:   '[data-dough-popup-content]',
-          popupClose:     '[data-dough-popup-close]',
-          activeClass:    'is-active',
-          inactiveClass:  'is-inactive',
-        }
-      },
-      PopupTip;
+    selectors: {
+      trigger:        '[data-dough-popup-trigger]',
+      popupContainer: '[data-dough-popup-container]',
+      popupContent:   '[data-dough-popup-content]',
+      popupClose:     '[data-dough-popup-close]',
+      activeClass:    'is-active',
+      inactiveClass:  'is-inactive',
+    }
+  },
+  PopupTip;
 
   PopupTip = function($el, config) {
     PopupTip.baseConstructor.call(this, $el, config, defaultConfig);
@@ -20,7 +20,7 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     this.$trigger = this.$el.find(this.config.selectors.trigger);
     this.$popup   = this.$el.find(this.config.selectors.popupContainer);
     this.$popupContent = this.$el.find(this.config.selectors.popupContent);
-    this.$component = this.$el;
+    this.$container = this.$el.parent();
     this.offset = 35;
     this.debounceWait = 100;
 
@@ -56,12 +56,12 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
   };
 
   PopupTip.prototype._positionPopup = function($index, trigger) {
-    var componentPos = this.$component[0].getBoundingClientRect();
+    var componentPos = this.$container[0].getBoundingClientRect();
     var triggerPos = trigger.getBoundingClientRect();
     var indexPos = $index[0].getBoundingClientRect();
 
-    this.$component.css('position', 'relative');
-    $index.css('width', this.$component.width());
+    this.$container.css('position', 'relative');
+    $index.css('width', this.$container.width());
 
     if (this.atSmallViewport()) {
       // mobile view

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.36.0'.freeze
+  VERSION = '5.36.1'.freeze
 end


### PR DESCRIPTION
[TP9755](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNTM0ODcyOThDQjBDMTMyMDgyMTBENEZEM0QwM0ZBQzkifQ==&boardPopup=userstory/9755/silent)

During the JQuery upgrade work on Dough an earlier piece of work, dealing with the positions of the Popup Tips was broken. This work restores the change that was removed. 

Currently on Preview: 
![image](https://user-images.githubusercontent.com/6080548/54289436-140da300-45a1-11e9-9473-54331e0a0add.png)

Updated
![image](https://user-images.githubusercontent.com/6080548/54298451-ae291780-45b0-11e9-86f0-7bdd97066269.png)

