### PR TITLE
TP-10385: Relax rails version restriction

### DIFF
--- a/dough-ruby.gemspec
+++ b/dough-ruby.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel'
   s.add_dependency 'activesupport'
-  s.add_dependency 'rails', '>= 3.2', '<= 5.0.6'
+  s.add_dependency 'rails', '>= 3.2', '< 5.1.0'
   s.add_dependency 'sass-rails'
 end

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.36.1'.freeze
+  VERSION = '5.36.2'.freeze
 end


### PR DESCRIPTION
Needed in order to bump Fincap Rails version: [TP-19385](https://moneyadviceservice.tpondemand.com/entity/10385-upgrade-fincap-rails-from-506-to)

We need to bump patch versions in apps (Eg: Fincap) using Rails 5.0.x
due to critical security updates.

The dependency restriction on Dough Ruby blocks upgrades of apps using
it to 5.0.7.

As everything under 5.0.x is a PATCH update meant to solve bugs or fix
security issues, with no feature changes, relaxing the Rails dependency
restriction to "Anything under Rails 5.1" will allow any further Patch
update in the host apps to be applied without having to come again to
update this restriction.

I assume that if we need to update any app using Dough to Rails 5.1/5.2
we will want to do specific testing to get sure they're compatible.