### PR TITLE
[DEV APPROVED] Added styles for popup span

### DIFF
--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -45,6 +45,13 @@
 
 .popup-tip__content {
   outline: none;
+  span:not(.popup-tip__title--no-js) {
+    display: block;
+    margin: 0 0 1em;
+  }
+  span:not(.popup-tip__title--no-js):last-child {
+    margin-bottom: 0;
+  }
 }
 
 .popup-tip__title {

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.36.2'.freeze
+  VERSION = '5.37.0'.freeze
 end


### PR DESCRIPTION
[TP 10495](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5253959470622112123&appConfig=eyJhY2lkIjoiNTM0ODcyOThDQjBDMTMyMDgyMTBENEZEM0QwM0ZBQzkifQ==&boardPopup=userstory/10495/silent)

Changes needed for styling of span elements inside popups.

These changes were made due to a ticket in the debt-advice-locator tool for a text change [PR159](https://github.com/moneyadviceservice/debt-advice-locator/pull/159).