### PR TITLE
TP 10508 Pop up tip overlap

### DIFF
--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -16,12 +16,13 @@
 }
 
 .popup-tip__container {
+  z-index: 2;
   .js & {
     padding: $baseline-unit*2;
     display: none;
     border: 2px solid $color-grey-dark;
     background-color: $color-white;
-    z-index: 1;
+    
     position: absolute;
     width: 100%;
 

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.37.0'.freeze
+  VERSION = '5.38.0'.freeze
 end


### PR DESCRIPTION
[TP 10508](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&boardPopup=userstory/10508/silent) and refer to [TP 9256](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=bug/9256)

### Summary
In some instances, the page content overlaps the popup-tip content. The first time this bug was noticed, it was fixed by adding a style to wpcc, [refer to pr#211 on wpcc](https://github.com/moneyadviceservice/wpcc/pull/211). Ideally the fix should have been applied to dough as the popup component is used across the site and should be designed to be dropped into any engine/tool without the need for customisation. 

This pr adds the requisite style to the dough component to ensure the popup content is not obscured by other page content.


