### PR TITLE
[DEV APPROVED] 10483 whatsapp webchat mobile interaction

### DIFF
--- a/assets/js/components/BackToTop.js
+++ b/assets/js/components/BackToTop.js
@@ -1,5 +1,5 @@
-define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
-  function($, DoughBaseComponent, mediaQueries, utilities) {
+define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'ChatPopup'],
+  function($, DoughBaseComponent, mediaQueries, utilities, ChatPopup) {
   'use strict';
 
   var BackToTop,
@@ -20,6 +20,9 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     this.showClass = 'back_to_top__link--shown';
     this.active = false;
     this.scrollingToTop = false;
+    // import the ChatPopup class
+    this.popupComponent = $(document).find('[data-dough-component="ChatPopup"]');
+    this.chatPopup = new ChatPopup(this.popupComponent);
   };
 
   /**
@@ -57,8 +60,8 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
     this.$bttLink
       .click(function() {
         $(this).removeClass(self.showClass);
+        self.chatPopup._raisedChatPopup(false, self.atSmallViewport);
         self.scrollingToTop = true;
-
         $('html, body').animate({scrollTop: 0}, 800, function() {
           self.scrollingToTop = false;
         });
@@ -84,9 +87,16 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
       this.atSmallViewport = true;
       this._position();
       this.$bttLink.removeClass(this.hiddenClass);
+      // on resize, validate scroll amount and manage raised class in whatsapp popup
+      if (this._getScrollAmount() < this.config.triggerPoint) {
+        this.chatPopup._raisedChatPopup(false, this.atSmallViewport);
+      } else {
+        this.chatPopup._raisedChatPopup(true, this.atSmallViewport);
+      }
     } else {
       this.atSmallViewport = false;
       this.$bttLink.addClass(this.hiddenClass);
+      this.chatPopup._raisedChatPopup(false, this.atSmallViewport);
     }
   };
 
@@ -103,9 +113,11 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities'],
       // we are beyond the scroll point
       if (this.active) {
         this.$bttLink.addClass(this.showClass);
+        this.chatPopup._raisedChatPopup(true, this.atSmallViewport);
       // we are not beyond the scroll point
       } else {
         this.$bttLink.removeClass(this.showClass);
+        this.chatPopup._raisedChatPopup(false, this.atSmallViewport);
       }
     }
   };

--- a/assets/js/components/ChatPopup.js
+++ b/assets/js/components/ChatPopup.js
@@ -1,0 +1,38 @@
+define(['jquery', 'DoughBaseComponent'],
+  function($, DoughBaseComponent) {
+  'use strict';
+
+  var ChatPopup,
+      defaultConfig = {};
+
+  ChatPopup = function($el, config) {
+    ChatPopup.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.chatPopupBtn = $el;
+  };
+
+  /**
+  * Inherit from base module, for shared methods and interface
+  */
+  DoughBaseComponent.extend(ChatPopup);
+
+  ChatPopup.componentName = 'ChatPopup';
+
+  /**
+   * Public method imported in BackToTop.js to manage popup vertical position in article pages
+   * @param {boolean} raised - set button raised state
+   * @param {boolean} atSmallViewport - viewport width < 720px
+   */
+  ChatPopup.prototype._raisedChatPopup = function(raised, atSmallViewport) {
+    raised && atSmallViewport ? this.chatPopupBtn.addClass('chat-popup--raised') : this.chatPopupBtn.removeClass('chat-popup--raised');
+  }
+
+  /**
+  * @param {Promise} initialised
+  */
+ ChatPopup.prototype.init = function(initialised) {
+    this._initialisedSuccess(initialised);
+  };
+
+  return ChatPopup;
+});

--- a/assets/js/components/ChatPopup.js
+++ b/assets/js/components/ChatPopup.js
@@ -1,38 +1,89 @@
 define(['jquery', 'DoughBaseComponent'],
-  function($, DoughBaseComponent) {
-  'use strict';
+  function ($, DoughBaseComponent) {
+    'use strict';
 
-  var ChatPopup,
+    var ChatPopup,
       defaultConfig = {};
 
-  ChatPopup = function($el, config) {
-    ChatPopup.baseConstructor.call(this, $el, config, defaultConfig);
+    ChatPopup = function ($el, config) {
+      ChatPopup.baseConstructor.call(this, $el, config, defaultConfig);
 
-    this.chatPopupBtn = $el;
-  };
+      this.chatPopupBtn = $el;
+      this.chatPopupIcon = $el.find('[data-dough-webchat-icon]');
+      this.chatPopupClose = $el.find('[data-dough-webchat-close]');
+      this.popupElements = $el.children().not('[data-dough-webchat-icon]');
+      this.serviceSelect = $el.find('[data-dough-webchat-select]');
+      this.whatsappBtn = $el.find('[data-dough-webchat-button-whatsapp]');
+      this.webchatBtn = $el.find('[data-dough-webchat-button-webchat]');
+    };
 
-  /**
-  * Inherit from base module, for shared methods and interface
-  */
-  DoughBaseComponent.extend(ChatPopup);
+    /**
+     * Inherit from base module, for shared methods and interface
+     */
+    DoughBaseComponent.extend(ChatPopup);
 
-  ChatPopup.componentName = 'ChatPopup';
+    ChatPopup.componentName = 'ChatPopup';
 
-  /**
-   * Public method imported in BackToTop.js to manage popup vertical position in article pages
-   * @param {boolean} raised - set button raised state
-   * @param {boolean} atSmallViewport - viewport width < 720px
-   */
-  ChatPopup.prototype._raisedChatPopup = function(raised, atSmallViewport) {
-    raised && atSmallViewport ? this.chatPopupBtn.addClass('chat-popup--raised') : this.chatPopupBtn.removeClass('chat-popup--raised');
-  }
+    ChatPopup.prototype._setupListeners = function () {
+      var self = this;
+      // on icon click open popup
+      this.chatPopupIcon.click(function (event) {
+        event.preventDefault();
+        self._togglePopup();
+        self._manageTransition(1);
+      });
+      // on X click close popup
+      this.chatPopupClose.click(function (event) {
+        event.preventDefault();
+        self._togglePopup();
+        self._manageTransition(0);
+      });
+      // on select change
+      this.serviceSelect.change(function(event) {
+        if(event.target.value === 'debt-and-borrowing' || event.target.value === 'pensions-and-retirement') {
+          self.whatsappBtn.removeClass('is-hidden');
+        } else {
+          self.whatsappBtn.addClass('is-hidden');
+        }
+      });
+    };
 
-  /**
-  * @param {Promise} initialised
-  */
- ChatPopup.prototype.init = function(initialised) {
-    this._initialisedSuccess(initialised);
-  };
+    ChatPopup.prototype._manageTransition = function (opacity) {
+      var self = this;
+      setTimeout(function () {
+        $.each(self.popupElements, function (index, value) {
+          value.style.opacity = opacity;
+          value.style.filter = "alpha(opacity=" + opacity + "00)"; // IE fallback
+        });
+      }, 100);
+    };
 
-  return ChatPopup;
-});
+    ChatPopup.prototype._togglePopup = function () {
+      this.chatPopupBtn.toggleClass('mobile-webchat--opened').toggleClass('mobile-webchat--closed');
+    };
+
+    /**
+     * Public method imported in BackToTop.js to manage popup vertical position in article pages
+     * @param {boolean} raised - set button raised state
+     * @param {boolean} atSmallViewport - viewport width < 720px
+     */
+    ChatPopup.prototype._raisedChatPopup = function (raised, atSmallViewport) {
+      var raisedPopup = raised && atSmallViewport;
+      // check if conditions are met
+      if (raisedPopup) {
+        this.chatPopupBtn.addClass('mobile-webchat--raised')
+      } else {
+        this.chatPopupBtn.removeClass('mobile-webchat--raised')
+      };
+    }
+
+    /**
+     * @param {Promise} initialised
+     */
+    ChatPopup.prototype.init = function (initialised) {
+      this._setupListeners();
+      this._initialisedSuccess(initialised);
+    };
+
+    return ChatPopup;
+  });

--- a/assets/stylesheets/components/common/_popup_tip.scss
+++ b/assets/stylesheets/components/common/_popup_tip.scss
@@ -45,6 +45,13 @@
 
 .popup-tip__content {
   outline: none;
+  span:not(.popup-tip__title--no-js) {
+    display: block;
+    margin: 0 0 1em;
+  }
+  span:not(.popup-tip__title--no-js):last-child {
+    margin-bottom: 0;
+  }
 }
 
 .popup-tip__title {

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.36.2'.freeze
+  VERSION = '5.37.0'.freeze
 end

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.38.0'.freeze
+  VERSION = '5.39.0'.freeze
 end

--- a/spec/js/fixtures/BackToTop.html
+++ b/spec/js/fixtures/BackToTop.html
@@ -1,18 +1,19 @@
 <div>
   <div>
     <div href="#" class="chat-popup__container mobile-webchat--closed" data-dough-component="ChatPopup">
-      <button class="mobile-webchat__close"></button>
-      <div class="mobile-webchat--icon"></div>
-      <select class="mobile-webchat__form-select">
-        <option value="debt_borrowing"></option>
-        <option value="work_benefits"></option>
-        <option value="pensions_retirement"></option>
+      <button class="mobile-webchat__close" data-dough-webchat-close></button>
+      <div class="mobile-webchat--icon" data-dough-webchat-icon></div>
+      <select class="mobile-webchat__form-select" data-dough-webchat-select>
+        <option value="debt-and-borrowing"></option>
+        <option value="work-and-benefits"></option>
+        <option value="pensions-and-retirement"></option>
       </select>
-      <a class="mobile-webchat__form-button--whatsapp"></a>
+      <a class="mobile-webchat__form-button--whatsapp" data-dough-webchat-button-whatsapp></a>
     </div>
     <div>
       <div data-dough-component="BackToTop"></div>
     </div>
+    <div data-dough-contact-panels></div>
     <div class="l-body">
       <footer>
         <div class="l-footer-secondary"></div>

--- a/spec/js/fixtures/BackToTop.html
+++ b/spec/js/fixtures/BackToTop.html
@@ -1,6 +1,15 @@
 <div>
   <div>
-    <a href="#" class="chat-popup__container" data-dough-component="ChatPopup"></a>
+    <div href="#" class="chat-popup__container mobile-webchat--closed" data-dough-component="ChatPopup">
+      <button class="mobile-webchat__close"></button>
+      <div class="mobile-webchat--icon"></div>
+      <select class="mobile-webchat__form-select">
+        <option value="debt_borrowing"></option>
+        <option value="work_benefits"></option>
+        <option value="pensions_retirement"></option>
+      </select>
+      <a class="mobile-webchat__form-button--whatsapp"></a>
+    </div>
     <div>
       <div data-dough-component="BackToTop"></div>
     </div>

--- a/spec/js/fixtures/BackToTop.html
+++ b/spec/js/fixtures/BackToTop.html
@@ -1,11 +1,13 @@
 <div>
   <div>
+    <a href="#" class="chat-popup__container" data-dough-component="ChatPopup"></a>
     <div>
       <div data-dough-component="BackToTop"></div>
     </div>
-
-    <footer>
-      <div class="l-footer-secondary"></div>
-    </footer>
+    <div class="l-body">
+      <footer>
+        <div class="l-footer-secondary"></div>
+      </footer>
+    </div>
   </div>
 </div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -23,6 +23,7 @@ require.config({
     mediaQueries: 'assets/js/lib/mediaQueries',
     componentLoader: 'assets/js/lib/componentLoader',
     BackToTop: 'assets/js/components/BackToTop',
+    ChatPopup: 'assets/js/components/ChatPopup',
     Collapsable: 'assets/js/components/Collapsable',
     CollapsableMobile: 'assets/js/components/CollapsableMobile',
     ConfirmableForm: 'assets/js/components/ConfirmableForm',

--- a/spec/js/tests/BackToTop_spec.js
+++ b/spec/js/tests/BackToTop_spec.js
@@ -4,25 +4,35 @@ describe('Back to Top link', function() {
   beforeEach(function(done) {
     var self = this;
 
+    fixture.setBase('spec/js/fixtures');
+
     requirejs(
-        ['jquery', 'BackToTop'],
-        function($, BackToTop) {
-          self.$html = $(window.__html__['spec/js/fixtures/BackToTop.html']);
-          self.component = self.$html.find('[data-dough-component="BackToTop"]');
+        ['jquery', 'BackToTop', 'ChatPopup'],
+        function($, BackToTop, ChatPopup) {
+          fixture.load('BackToTop.html');
+
+          self.component = $(fixture.el).find('[data-dough-component="BackToTop"]');
+          self.component.height(4000);
+
           self.backToTop = new BackToTop(self.component);
           self.triggerPoint = self.backToTop.config.triggerPoint;
           self.showClass = self.backToTop.showClass;
-          self.component.height(4000);
-
+          
           self.backToTop.init();
-          self.back_to_top_link = self.$html.find('.back_to_top__link');
+
+          self.back_to_top_link = $(fixture.el).find('.back_to_top__link');
+
+          self.ChatPopup = ChatPopup;
+          self.$popupComponent = $(fixture.el).find('[data-dough-component="ChatPopup"]');
+          self.chatPopup = new ChatPopup(self.$popupComponent);
+          self.chatPopup.init();
 
           done();
         }, done);
   });
 
   afterEach(function() {
-    this.$html.remove();
+    fixture.cleanup();
   });
 
   describe('Set up link', function() {
@@ -33,7 +43,7 @@ describe('Back to Top link', function() {
 
   describe('Set up footer', function() {
     it('Adds extra space to footer', function() {
-      expect(this.$html.find('.l-footer-secondary')).to.have.class('back_to_top__spacer');
+      expect($(fixture.el).find('.l-footer-secondary')).to.have.class('back_to_top__spacer');
     });
   });
 
@@ -69,7 +79,12 @@ describe('Back to Top link', function() {
 
   describe('Tests link behaviour when activated', function() {
     beforeEach(function() {
+      this.popupSpy = sinon.spy(this.ChatPopup.prototype, '_raisedChatPopup');
       this.back_to_top_link.trigger('click');
+    });
+
+    afterEach(function() {
+      this.popupSpy.restore();
     });
 
     it('Returns user to top of page when clicked', function() {
@@ -78,6 +93,11 @@ describe('Back to Top link', function() {
 
     it('Hides link when clicked', function() {
       expect(this.back_to_top_link).to.not.have.class(this.showClass);
+    });
+
+    it('Lowers the Chatpopup when back to top is clicked', function() {
+      sinon.assert.called(this.popupSpy);
+      expect(this.popupSpy.getCalls()[0].args[0]).to.equals(false);
     });
   });
 });

--- a/spec/js/tests/ChatPopup_spec.js
+++ b/spec/js/tests/ChatPopup_spec.js
@@ -19,6 +19,10 @@ describe('Chat Popup', function() {
 
           self.ChatPopup = ChatPopup;
           self.$popupComponent = $(fixture.el).find('[data-dough-component="ChatPopup"]');
+          self.chatPopupIcon = $(fixture.el).find('div.mobile-webchat--icon');
+          self.chatPopupCloseBtn = $(fixture.el).find('button.mobile-webchat__close');
+          self.chatPopupSelect = $(fixture.el).find('.mobile-webchat__form-select');
+          self.whatsappBtn = $(fixture.el).find('.mobile-webchat__form-button--whatsapp');
           self.chatPopup = new ChatPopup(self.$popupComponent);
           self.chatPopup.init();
           
@@ -30,22 +34,67 @@ describe('Chat Popup', function() {
     fixture.cleanup();
   });
 
+  describe('Opening and Closing Popup', function() {
+
+    beforeEach(function() {
+      this.openSpy = sinon.spy(this.ChatPopup.prototype, '_togglePopup');
+    });
+
+    afterEach(function() {
+      this.openSpy.restore();
+    });
+
+    it('Opens popup on click', function() {
+      this.chatPopupIcon.click();
+      sinon.assert.calledOnce(this.openSpy);
+      expect(this.$popupComponent).not.to.have.class('mobile-webchat--closed');
+      expect(this.$popupComponent).to.have.class('mobile-webchat--opened');
+    });
+
+    it('Closes popup on X button click', function() {
+      this.chatPopupIcon.click();
+      sinon.assert.calledOnce(this.openSpy);
+      this.chatPopupCloseBtn.click();
+      sinon.assert.calledTwice(this.openSpy);
+      expect(this.$popupComponent).not.to.have.class('mobile-webchat--opened');
+      expect(this.$popupComponent).to.have.class('mobile-webchat--closed');
+    });
+
+  });
+
+  describe('Popup Select Change Events', function() {
+
+    it('Changes Select to Work & Benefits', function() {
+      this.chatPopupSelect.val('work_benefits').change();
+      expect(this.whatsappBtn).to.have.class('is-hidden');
+    });
+
+    it('Changes Select to Debt & Borrowing', function() {
+      this.chatPopupSelect.val('debt_borrowing').change();
+      expect(this.whatsappBtn).not.to.have.class('is-hidden');
+    });
+
+    it('Changes Select to Pensions & Retirement', function() {
+      this.chatPopupSelect.val('pensions_retirement').change();
+      expect(this.whatsappBtn).not.to.have.class('is-hidden');
+    });
+
+  });
+
   describe('Raising the Webchat and Whatsapp popup in article pages', function() {
 
     beforeEach(function() {
       this.stub = sinon.stub(this.backToTop, '_getScrollAmount');
-      
       this.popupSpy = sinon.spy(this.ChatPopup.prototype, '_raisedChatPopup');
     });
 
     afterEach(function() {
       this.stub.restore();
-
       this.popupSpy.restore();
     });
 
     it('Validates original popup state', function() {
-      expect(this.$popupComponent).not.to.have.class('chat-popup--raised');
+      expect(this.$popupComponent).not.to.have.class('mobile-webchat--raised');
     });
 
     it('Raises the popup in article pages on small screens', function() {
@@ -54,10 +103,10 @@ describe('Chat Popup', function() {
       $(window).trigger('scroll');
       if (this.backToTop.atSmallViewport) {
         sinon.assert.called(this.popupSpy);
-        expect(this.$popupComponent).to.have.class('chat-popup--raised');
+        expect(this.$popupComponent).to.have.class('mobile-webchat--raised');
       } else {
         sinon.assert.notCalled(this.popupSpy);
-        expect(this.$popupComponent).not.to.have.class('chat-popup--raised');
+        expect(this.$popupComponent).not.to.have.class('mobile-webchat--raised');
       }
       
     });
@@ -65,7 +114,7 @@ describe('Chat Popup', function() {
       // simulate scrolling to before the trigger point
       this.stub.returns(this.triggerPoint - 1);
       $(window).trigger('scroll');
-      expect(this.$popupComponent).not.to.have.class('chat-popup--raised');
+      expect(this.$popupComponent).not.to.have.class('mobile-webchat--raised');
       if (this.backToTop.atSmallViewport) {
         sinon.assert.called(this.popupSpy);
         expect(this.popupSpy.getCalls()[0].args[0]).to.equals(false);

--- a/spec/js/tests/ChatPopup_spec.js
+++ b/spec/js/tests/ChatPopup_spec.js
@@ -1,0 +1,78 @@
+describe('Chat Popup', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    fixture.setBase('spec/js/fixtures');
+
+    requirejs(
+        ['jquery', 'BackToTop', 'ChatPopup'],
+        function($, BackToTop, ChatPopup) {
+          fixture.load('BackToTop.html');
+
+          self.$backToTopcomponent = $(fixture.el).find('[data-dough-component="BackToTop"]');
+          self.backToTop = new BackToTop(self.$backToTopcomponent);
+          self.triggerPoint = self.backToTop.config.triggerPoint;
+          self.$backToTopcomponent.height(4000);
+          self.backToTop.init();
+
+          self.ChatPopup = ChatPopup;
+          self.$popupComponent = $(fixture.el).find('[data-dough-component="ChatPopup"]');
+          self.chatPopup = new ChatPopup(self.$popupComponent);
+          self.chatPopup.init();
+          
+          done();
+        }, done);
+  });
+
+  afterEach(function() {
+    fixture.cleanup();
+  });
+
+  describe('Raising the Webchat and Whatsapp popup in article pages', function() {
+
+    beforeEach(function() {
+      this.stub = sinon.stub(this.backToTop, '_getScrollAmount');
+      
+      this.popupSpy = sinon.spy(this.ChatPopup.prototype, '_raisedChatPopup');
+    });
+
+    afterEach(function() {
+      this.stub.restore();
+
+      this.popupSpy.restore();
+    });
+
+    it('Validates original popup state', function() {
+      expect(this.$popupComponent).not.to.have.class('chat-popup--raised');
+    });
+
+    it('Raises the popup in article pages on small screens', function() {
+      // simulate scrolling to over the trigger point
+      this.stub.returns(this.triggerPoint);
+      $(window).trigger('scroll');
+      if (this.backToTop.atSmallViewport) {
+        sinon.assert.called(this.popupSpy);
+        expect(this.$popupComponent).to.have.class('chat-popup--raised');
+      } else {
+        sinon.assert.notCalled(this.popupSpy);
+        expect(this.$popupComponent).not.to.have.class('chat-popup--raised');
+      }
+      
+    });
+    it('Doesn\'t raise the popup before trigger point', function() {
+      // simulate scrolling to before the trigger point
+      this.stub.returns(this.triggerPoint - 1);
+      $(window).trigger('scroll');
+      expect(this.$popupComponent).not.to.have.class('chat-popup--raised');
+      if (this.backToTop.atSmallViewport) {
+        sinon.assert.called(this.popupSpy);
+        expect(this.popupSpy.getCalls()[0].args[0]).to.equals(false);
+      } else {
+        sinon.assert.notCalled(this.popupSpy);
+      }
+    });
+  });
+
+});


### PR DESCRIPTION
Part of [TP 10483](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5253959470622112123&appConfig=eyJhY2lkIjoiNTM0ODcyOThDQjBDMTMyMDgyMTBENEZEM0QwM0ZBQzkifQ==&searchPopup=feature/10483)

This PR merges tickets 10484, 10485 and 10486 into master.

Floating webchat icon in the bottom right of the page and when I tap it then I should see a dropdown of categories with a 'Start web chat' button always visible and when I select either Pensions & Retirement or Debt & Borrowing then I should also see the 'Start Whatsapp' button and when I tap either of these buttons then that should initiate the appropriate chat as per the page footers.

And when I begin to scroll then the icon should slide out, leaving behind a small tab which reveals the popup on click.