### PR TITLE
11363 sticky banner coronavirus info

### DIFF
--- a/assets/js/components/BackToTop.js
+++ b/assets/js/components/BackToTop.js
@@ -1,5 +1,5 @@
-define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'ChatPopup'],
-  function($, DoughBaseComponent, mediaQueries, utilities, ChatPopup) {
+define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'ChatPopup', 'CovidBanner'],
+  function($, DoughBaseComponent, mediaQueries, utilities, ChatPopup, CovidBanner) {
   'use strict';
 
   var BackToTop,
@@ -23,6 +23,13 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'ChatPopup'
     // import the ChatPopup class
     this.popupComponent = $(document).find('[data-dough-component="ChatPopup"]');
     this.chatPopup = new ChatPopup(this.popupComponent);
+    // import the CovidBanner class
+    if ($(document).find('[data-dough-component="CovidBanner"]').length > 0) {
+      this.covidComponent = $(document).find('[data-dough-component="CovidBanner"]');
+      this.covidBanner = new CovidBanner(this.covidComponent);
+    } else {
+      this.covidBanner = null; 
+    }
   };
 
   /**
@@ -90,13 +97,22 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'ChatPopup'
       // on resize, validate scroll amount and manage raised class in whatsapp popup
       if (this._getScrollAmount() < this.config.triggerPoint) {
         this.chatPopup._raisedChatPopup(false, this.atSmallViewport);
+        if (this.covidBanner) {
+          this.covidBanner._raisedCovidBanner(false, this.atSmallViewport);
+        }
       } else {
         this.chatPopup._raisedChatPopup(true, this.atSmallViewport);
+        if (this.covidBanner) {
+          this.covidBanner._raisedCovidBanner(true, this.atSmallViewport);
+        }
       }
     } else {
       this.atSmallViewport = false;
       this.$bttLink.addClass(this.hiddenClass);
       this.chatPopup._raisedChatPopup(false, this.atSmallViewport);
+      if (this.covidBanner) {
+        this.covidBanner._raisedCovidBanner(false, this.atSmallViewport);
+      }
     }
   };
 
@@ -114,10 +130,16 @@ define(['jquery', 'DoughBaseComponent', 'mediaQueries', 'utilities', 'ChatPopup'
       if (this.active) {
         this.$bttLink.addClass(this.showClass);
         this.chatPopup._raisedChatPopup(true, this.atSmallViewport);
+        if (this.covidBanner) {
+          this.covidBanner._raisedCovidBanner(true, this.atSmallViewport);
+        }
       // we are not beyond the scroll point
       } else {
         this.$bttLink.removeClass(this.showClass);
         this.chatPopup._raisedChatPopup(false, this.atSmallViewport);
+        if (this.covidBanner) {
+          this.covidBanner._raisedCovidBanner(false, this.atSmallViewport);
+        }
       }
     }
   };

--- a/assets/js/components/CovidBanner.js
+++ b/assets/js/components/CovidBanner.js
@@ -1,0 +1,74 @@
+define(['jquery', 'DoughBaseComponent'],
+  function($, DoughBaseComponent) {
+  'use strict';
+
+  var CovidBanner,
+      defaultConfig = {};
+
+  CovidBanner = function($el, config) {
+    CovidBanner.baseConstructor.call(this, $el, config, defaultConfig);
+
+    this.closeBtn = this.$el.find('[data-dough-close]'); 
+    this.hideClass = 'covid_banner--hidden'; 
+    this.raisedClass = 'covid_banner--raised'; 
+  };
+
+  /**
+  * Inherit from base module, for shared methods and interface
+  */
+  DoughBaseComponent.extend(CovidBanner);
+
+  CovidBanner.componentName = 'CovidBanner';
+
+  /**
+  * @param {Promise} initialised
+  */
+  CovidBanner.prototype.init = function(initialised) {
+    this._initialisedSuccess(initialised);
+    this._setUpEvents(); 
+  };
+
+  CovidBanner.prototype._setUpEvents = function() {
+    var _this = this; 
+
+    this.closeBtn.click(function(e) {
+      e.preventDefault(); 
+      _this._setCookie(); 
+      _this._hideBanner(); 
+    }); 
+  }; 
+
+  CovidBanner.prototype._setCookie = function() {
+    // check if the _covid_banner cookie exists
+    var allCookies = document.cookie.replace(/ /g, '').split(';'); 
+    var cookieExists = allCookies.some(function(item) {
+      return item.indexOf('_covid_banner=') == 0; 
+    }); 
+
+    // if not then create it with a value of 'y'
+    if (!cookieExists) {
+      document.cookie = '_covid_banner=y';      
+    }
+  }; 
+
+  CovidBanner.prototype._hideBanner = function() {
+    this.$el.addClass(this.hideClass); 
+  }; 
+
+  /**
+   * Public method imported in BackToTop.js to manage popup vertical position in article pages
+   * @param {boolean} raised - set button raised state
+   * @param {boolean} atSmallViewport - viewport width < 720px
+   */
+  CovidBanner.prototype._raisedCovidBanner = function(raised, atSmallViewport) {
+    var raisedBanner = raised && atSmallViewport;
+    // check if conditions are met
+    if (raisedBanner) {
+      this.$el.addClass(this.raisedClass)
+    } else {
+      this.$el.removeClass(this.raisedClass)
+    };
+  }
+
+  return CovidBanner;
+});

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '6.0.0'.freeze
+  VERSION = '6.1.0'.freeze
 end

--- a/spec/js/fixtures/CovidBanner.html
+++ b/spec/js/fixtures/CovidBanner.html
@@ -1,0 +1,7 @@
+<div>
+  <div data-dough-component="CovidBanner">
+    <div>
+      <a data-dough-close></a>
+    </div>
+  </div>
+</div>

--- a/spec/js/test-main.js
+++ b/spec/js/test-main.js
@@ -26,6 +26,7 @@ require.config({
     ChatPopup: 'assets/js/components/ChatPopup',
     Collapsable: 'assets/js/components/Collapsable',
     CollapsableMobile: 'assets/js/components/CollapsableMobile',
+    CovidBanner: 'assets/js/components/CovidBanner',
     ConfirmableForm: 'assets/js/components/ConfirmableForm',
     PopupTip: 'assets/js/components/PopupTip',
     Print: 'assets/js/components/Print',

--- a/spec/js/tests/CovidBanner_spec.js
+++ b/spec/js/tests/CovidBanner_spec.js
@@ -1,0 +1,92 @@
+describe('Coronavirus Banner', function() {
+  'use strict';
+
+  beforeEach(function(done) {
+    var self = this;
+
+    fixture.setBase('spec/js/fixtures');
+
+    requirejs(
+        ['jquery', 'CovidBanner'],
+        function($, CovidBanner) {
+          fixture.load('CovidBanner.html');
+
+          self.component = $(fixture.el).find('[data-dough-component="CovidBanner"]');
+          self.closeBtn = $(fixture.el).find('[data-dough-close]');
+          self.CovidBanner = new CovidBanner(self.component);    
+          self.hideClass = self.CovidBanner.hideClass;
+
+          done();
+        }, done);
+  });
+
+  afterEach(function() {
+    fixture.cleanup();
+  });
+
+  describe('When the component is initialised', function() {
+    beforeEach(function() {
+      this.setUpEventsSpy = sinon.spy(this.CovidBanner, '_setUpEvents'); 
+    });
+
+    afterEach(function() {
+      this.setUpEventsSpy.restore(); 
+    }); 
+
+    it('Calls the setUpEvents method', function() {
+      this.CovidBanner.init();
+
+      expect(this.setUpEventsSpy.calledOnce).to.be.true; 
+    }); 
+  }); 
+
+  describe('When the close icon is clicked', function() {
+    beforeEach(function() {
+      this.CovidBanner.init(); 
+      this.setCookieSpy = sinon.spy(this.CovidBanner, '_setCookie');
+      this.hideBannerSpy = sinon.spy(this.CovidBanner, '_hideBanner');
+    }); 
+
+    afterEach(function() {
+      this.setCookieSpy.restore(); 
+      this.hideBannerSpy.restore(); 
+    }); 
+
+    it('Calls the setCookie method', function() {
+      this.closeBtn.trigger('click'); 
+
+      expect(this.setCookieSpy.calledOnce).to.be.true;
+    });
+
+    it('Calls the hideBanner method', function() {
+      this.closeBtn.trigger('click'); 
+
+      expect(this.hideBannerSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('When the setCookie method is called', function() {
+    beforeEach(function() {
+      // Create some random cookies
+      document.cookie = '';
+      document.cookie = 'firstcookie=randomcookie';
+      document.cookie = 'secondcookie=anotherrandomcookie';
+    }); 
+
+    it('Sets the cookie to the correct value', function() {
+      this.CovidBanner._setCookie(); 
+
+      var allCookies = document.cookie.replace(/ /g, ''); 
+
+      expect(allCookies.indexOf('_covid_banner=y') >= 0).to.be.true; 
+    }); 
+  }); 
+
+  describe('When the hideBanner method is called', function() {
+    it('Hides the banner', function() {
+      this.CovidBanner._hideBanner(); 
+
+      expect(this.component).to.have.class(this.hideClass); 
+    }); 
+  }); 
+});


### PR DESCRIPTION
[TP11363](https://maps.tpondemand.com/entity/11363-sticky-banner-on-mas-website-for)

This work adds a banner to direct users to our articles on Coronavirus. 

There are three PRs that make up the implementation of this component: 
- [PR2201](https://github.com/moneyadviceservice/frontend/pull/2201) in frontend that provides the content and markup for the banner, as well as the Rails functionality to render the component only when this is not recorded in a Cookie as having been previously dismissed, and the reference to the associated Dough component. 
- [PR61](https://github.com/moneyadviceservice/yeast/pull/61) in yeast that provides the styles for the component, and which will be shared with other repos, such as RAD. 
- PR338 in dough (this PR) that provides the JavaScript component and associated Unit Tests for the behaviour of the banner. This PR also updates the ChatPopup component, necessary to handle the dynamic positioning of the banner on article pages. 

**Banner on the home page**

![image](https://user-images.githubusercontent.com/6080548/77449907-7a4f1780-6dea-11ea-9885-7ffabf3969fc.png)

**Banner on an article page**

![image](https://user-images.githubusercontent.com/6080548/77450028-9e125d80-6dea-11ea-9eca-52217aa2a05e.png)
