### PR TITLE
11393 chat add coronavirus option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.63.1', require: false
   gem 'rubocop-rspec'
+  gem 'sass'
   gem 'shoulda-matchers', '~> 2.8.0' # Dough targets 1.9.3 so we need to lock shoulda-matchers to < 3.0
   gem 'sprockets', '~> 3.7.2'
   gem 'tzinfo-data'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.63.1', require: false
   gem 'rubocop-rspec'
   gem 'shoulda-matchers', '~> 2.8.0' # Dough targets 1.9.3 so we need to lock shoulda-matchers to < 3.0
+  gem 'sprockets', '~> 3.7.2'
   gem 'tzinfo-data'
 end
 

--- a/assets/js/components/ChatPopup.js
+++ b/assets/js/components/ChatPopup.js
@@ -46,7 +46,7 @@ define(['jquery', 'DoughBaseComponent'],
       });
       // on select change
       this.serviceSelect.change(function(event) {
-        if (event.target.value === 'debt-and-borrowing' || event.target.value === 'pensions-and-retirement') {
+        if (event.target.value === 'debt-and-borrowing' || event.target.value === 'pensions-and-retirement'  || event.target.value === 'coronavirus') {
           self.whatsappBtn.removeClass('is-hidden');
         } else {
           self.whatsappBtn.addClass('is-hidden');

--- a/spec/js/fixtures/BackToTop.html
+++ b/spec/js/fixtures/BackToTop.html
@@ -7,6 +7,7 @@
         <option value="debt-and-borrowing"></option>
         <option value="work-and-benefits"></option>
         <option value="pensions-and-retirement"></option>
+        <option value="coronavirus"></option>
       </select>
       <a class="mobile-webchat__form-button--whatsapp" data-dough-webchat-button-whatsapp></a>
     </div>

--- a/spec/js/tests/ChatPopup_spec.js
+++ b/spec/js/tests/ChatPopup_spec.js
@@ -82,6 +82,10 @@ describe('Chat Popup', function() {
       expect(this.whatsappBtn).not.to.have.class('is-hidden');
     });
 
+    it('Changes Select to Coronavirus', function() {
+      this.chatPopupSelect.val('coronavirus').change();
+      expect(this.whatsappBtn).not.to.have.class('is-hidden');
+    });
   });
 
   describe('Raising the Webchat and Whatsapp popup in article pages', function() {


### PR DESCRIPTION
[TP11393](https://maps.tpondemand.com/entity/11393-add-coronavirus-to-dropdown-option-on)

These changes provides the logic to show the WhatsApp link when the newly-added Coronavirus option is selected in the floating WebChat dropdown, the change made in [PR2205](https://github.com/moneyadviceservice/frontend/pull/2205) in frontend. 

![image](https://user-images.githubusercontent.com/6080548/79229598-34bac300-7e5b-11ea-94b5-75a4a4decd5f.png)
