### PR TITLE
12213 third party cookies update link

### DIFF
--- a/assets/js/components/ThirdPartyCookieAccess.js
+++ b/assets/js/components/ThirdPartyCookieAccess.js
@@ -63,13 +63,15 @@ define(['ThirdPartyCookieAccess'], function(ThirdPartyCookieAccess) {
 
 	ThirdPartyCookieAccess.prototype.renderLink = function() {
 		var frame = window.frames,
-				href = frame.location.href, 
+				href = frame.location.href
+					.replace(/[a-z-]*partner-tools/, 'www')
+					.replace(/dev.mas.local/, 'moneyadviceservice.org.uk'),
 				locale = frame.I18n.locale, 
 				message = document.createElement('div'), 
 				header, 
 				headerStyles = {
 					'margin-top': 0,
-					'background-image': 'url(/assets/dough/assets/images/exclamation_mark.svg)',
+					'background-image': 'url(/../../images/exclamation_mark.svg)',
 					'background-repeat': 'no-repeat',
 					'background-position': 'left center',
 					'background-size': '2.25rem',

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.42.0'.freeze
+  VERSION = '5.42.1'.freeze
 end


### PR DESCRIPTION
[TP-12213](https://maps.tpondemand.com/entity/12213-replace-link-on-safari-message-for)

This work essentially replaces a link added in a previous piece of work ([TP-11920](https://maps.tpondemand.com/entity/11920-credit-card-calculator-implement-the-storage)) to provide users of syndicated tools with a means of continuing to use a tool when their browser blocks the use of third party cookies. Originally that referred users to the `partner-tools` sub-domain but that was not always a great experience for the user and not really a correct use of that sub-domain. In this work we are dynamically generating a URL to the tool on the MAS site instead. 

This PR also requires [PR-2329](https://github.com/moneyadviceservice/frontend/pull/2329) on frontend to deploy it to the Credit Card Calculator. 