### PR TITLE
Post messages v5.44

### DIFF
--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -50,12 +50,20 @@ define(['DoughBaseComponent'],
   }
 
   /**
-   * Updates the message with vertical offset value for the supplied element
+   * Updates the message with required value
    */
-  PostMessages.prototype._updateMessage = function(id) {
-    var offset = this._getOffset(id);
-    this.message.jumpLink.id = id;
-    this.message.jumpLink.offset = offset;
+  PostMessages.prototype._updateMessage = function(event, value) {
+    console.log('value: ', value);
+    console.log('event: ', event);
+
+    if (event === 'masResize') {
+
+    } else {
+      // Updates the message with vertical offset value for the supplied element
+      var offset = this._getOffset(value);
+      this.message.jumpLink.id = value;
+      this.message.jumpLink.offset = offset;
+    }
 
     this._sendMessage(); 
   }

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -8,7 +8,9 @@ define(['DoughBaseComponent'],
   'use strict';
 
   var PostMessages, 
-      defaultConfig = {}, 
+      defaultConfig = {
+        masresize: false
+      },
       message = {
         jumpLink: {
           id: '', 
@@ -30,12 +32,13 @@ define(['DoughBaseComponent'],
   PostMessages.componentName = 'PostMessages';
 
   /** 
-   * Adds listeners for click events to jump links
+   * Adds event listeners
    */
   PostMessages.prototype._addEvents = function() {
     var _this = this;
     var anchors = this.$el.find('a');
 
+    // Adds listeners for click events to jump links
     for (var anchor in anchors) {
       if (anchors[anchor].href && anchors[anchor].href.indexOf('#') > -1) {
         $(anchors[anchor]).on('click', function(e) {
@@ -74,11 +77,22 @@ define(['DoughBaseComponent'],
   }
 
   /**
+   * A method to listen for changes to the document height
+   */
+  PostMessages.prototype._masResize = function() {
+    console.log('masResize!'); 
+  }
+
+  /**
   * @param {Promise} initialised
   */
   PostMessages.prototype.init = function(initialised) {
     this._initialisedSuccess(initialised);
-    this._addEvents(); 
+    this._addEvents();
+
+    if (this.config.masresize === true) {
+      this._masResize(); 
+    }
   };
 
   return PostMessages;

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -79,6 +79,8 @@ define(['DoughBaseComponent'],
    * Sends the message
    */
   PostMessages.prototype._sendMessage = function() {
+    console.log('message: ', this.message); 
+    
     window.parent.postMessage(this.message, '*');
   }
 
@@ -86,8 +88,6 @@ define(['DoughBaseComponent'],
    * A method to listen for changes to the document height
    */
   PostMessages.prototype._masResize = function(masResize) {
-    console.log('masResize!'); 
-
     var _this = this, 
         currentHeight = 0, 
         timer,

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -79,8 +79,26 @@ define(['DoughBaseComponent'],
   /**
    * A method to listen for changes to the document height
    */
-  PostMessages.prototype._masResize = function() {
+  PostMessages.prototype._masResize = function(masResize) {
     console.log('masResize!'); 
+
+    var _this = this, 
+        currentHeight = 0, 
+        timer,
+        bodyNode = document.body, 
+        minFrameHeight = 250;
+
+    timer = setInterval(function() {
+      var documentHeight = Math.max(
+        bodyNode.scrollHeight,
+        minFrameHeight
+      );
+
+      if (documentHeight !== currentHeight) {
+        currentHeight = documentHeight;
+        _this._updateMessage('masResize', documentHeight);
+      }
+    }, 200);
   }
 
   /**

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -43,7 +43,7 @@ define(['DoughBaseComponent'],
       if (anchors[anchor].href && anchors[anchor].href.indexOf('#') > -1) {
         $(anchors[anchor]).on('click', function(e) {
           e.preventDefault();
-          _this._updateMessage(e.target.href.split('#')[1]);
+          _this._updateMessage('jumpLink', e.target.href.split('#')[1]);
         })
       }
     };
@@ -58,7 +58,7 @@ define(['DoughBaseComponent'],
 
     if (event === 'masResize') {
 
-    } else {
+    } else if (event === 'jumpLink') {
       // Updates the message with vertical offset value for the supplied element
       var offset = this._getOffset(value);
       this.message.jumpLink.id = value;

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -8,14 +8,9 @@ define(['DoughBaseComponent'],
   'use strict';
 
   var PostMessages, 
+      message,
       defaultConfig = {
         masresize: false
-      },
-      message = {
-        jumpLink: {
-          id: '', 
-          offset: 0
-        }
       };
 
   PostMessages = function($el, config) {
@@ -53,16 +48,19 @@ define(['DoughBaseComponent'],
    * Updates the message with required value
    */
   PostMessages.prototype._updateMessage = function(event, value) {
-    console.log('value: ', value);
-    console.log('event: ', event);
-
     if (event === 'masResize') {
-
+      // Updates the message with height value for document
+      this.message = '';
+      this.message = 'MASRESIZE-' + value;
     } else if (event === 'jumpLink') {
       // Updates the message with vertical offset value for the supplied element
       var offset = this._getOffset(value);
-      this.message.jumpLink.id = value;
-      this.message.jumpLink.offset = offset;
+
+      this.message = {}; 
+      this.message['jumpLink'] = {
+        id: value,
+        offset: offset
+      };
     }
 
     this._sendMessage(); 

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -114,7 +114,7 @@ define(['DoughBaseComponent'],
     this._initialisedSuccess(initialised);
     this._addEvents();
 
-    if (this.config.masresize === true) {
+    if (this.config.masresize) {
       this._masResize(); 
     }
   };

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.43.0'.freeze
+  VERSION = '5.44.0'.freeze
 end

--- a/spec/js/fixtures/PostMessages.html
+++ b/spec/js/fixtures/PostMessages.html
@@ -27,9 +27,14 @@
   </div>
 
   <style type="text/css">
+    body, 
     body * {
       margin: 0;
       padding: 0;
+    }
+
+    body {
+      height: 1200px;
     }
 
     #content_1, 

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -90,7 +90,7 @@ describe('PostMessages component', function() {
     })
   });
 
-  describe.only('On calling the updateMessage method', function() {
+  describe('On calling the updateMessage method', function() {
     it('Calls the getOffset method where required with the correct argument', function() {
       var getOffsetSpy = sinon.spy(this.postMessages, '_getOffset');
 

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -23,7 +23,7 @@ describe('PostMessages component', function() {
     fixture.cleanup();
   });
 
-  describe('On initialising', function() {
+  describe.only('On initialising', function() {
     it('Calls the _addEvents method', function() {
       var addEventsSpy = sinon.spy(this.postMessages, '_addEvents'); 
 
@@ -32,6 +32,19 @@ describe('PostMessages component', function() {
 
       addEventsSpy.restore(); 
     });
+
+    it('Calls the masresize method if method config is true', function() {
+      var masResizeSpy = sinon.spy(this.postMessages, '_masResize'); 
+
+      this.postMessages.init(); 
+      expect(masResizeSpy.called).to.be.false; 
+
+      this.postMessages.config.masresize = true; 
+      this.postMessages.init(); 
+      expect(masResizeSpy.calledOnce).to.be.true; 
+
+      masResizeSpy.restore();
+    }); 
   });
 
   describe('On clicking a jump link', function() {

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -23,7 +23,7 @@ describe('PostMessages component', function() {
     fixture.cleanup();
   });
 
-  describe.only('On initialising', function() {
+  describe('On initialising', function() {
     it('Calls the _addEvents method', function() {
       var addEventsSpy = sinon.spy(this.postMessages, '_addEvents'); 
 
@@ -33,7 +33,7 @@ describe('PostMessages component', function() {
       addEventsSpy.restore(); 
     });
 
-    it('Calls the masresize method if method config is true', function() {
+    it('Calls the masResize method if method config is true', function() {
       var masResizeSpy = sinon.spy(this.postMessages, '_masResize'); 
 
       this.postMessages.init(); 
@@ -46,6 +46,22 @@ describe('PostMessages component', function() {
       masResizeSpy.restore();
     }); 
   });
+
+  describe.only('masResize method', function() {
+    it('Calls the updateMessage method with the correct argument on body resize', function() {
+      var clock = sinon.useFakeTimers();
+      var updateMessageSpy = sinon.spy(this.postMessages, '_updateMessage');
+
+      this.postMessages._masResize();
+      clock.tick(200);
+
+      expect(updateMessageSpy.callCount).to.equal(1); 
+      expect(updateMessageSpy.calledWith('masResize', 1200)).to.be.true; 
+
+      clock.restore(); 
+      updateMessageSpy.restore(); 
+    }); 
+  }); 
 
   describe('On clicking a jump link', function() {
     it('Calls the updateMessage method with the correct argument', function() {

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -1,4 +1,4 @@
-describe.only('PostMessages component', function() {
+describe('PostMessages component', function() {
   'use strict';
 
   beforeEach(function(done) {
@@ -13,7 +13,6 @@ describe.only('PostMessages component', function() {
 
         self.component = $(fixture.el).find('[data-dough-component="PostMessages"]');
         self.postMessages = new PostMessages(self.component);
-        self.message = self.postMessages.message; 
 
         done();
       }, done);
@@ -91,7 +90,7 @@ describe.only('PostMessages component', function() {
     })
   });
 
-  describe('On calling the updateMessage method', function() {
+  describe.only('On calling the updateMessage method', function() {
     it('Calls the getOffset method where required with the correct argument', function() {
       var getOffsetSpy = sinon.spy(this.postMessages, '_getOffset');
 
@@ -114,15 +113,20 @@ describe.only('PostMessages component', function() {
     }); 
 
     it('Updates the message with the correct values', function() {
+      // For jumpLink event
       var getOffsetStub = sinon.stub(this.postMessages, '_getOffset');
 
       getOffsetStub.returns(120); 
       this.postMessages._updateMessage('jumpLink', 'content_1');
 
-      expect(this.message.jumpLink.id).to.equal('content_1'); 
-      expect(this.message.jumpLink.offset).to.equal(120); 
+      expect(this.postMessages.message.jumpLink.id).to.equal('content_1'); 
+      expect(this.postMessages.message.jumpLink.offset).to.equal(120); 
 
       getOffsetStub.restore(); 
+
+      // For masResize event
+      this.postMessages._updateMessage('masResize', 1200);
+      expect(this.postMessages.message).to.equal('MASRESIZE-1200'); 
     }); 
 
     it('Calls the sendMessage method', function() {

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -92,7 +92,7 @@ describe.only('PostMessages component', function() {
   });
 
   describe('On calling the updateMessage method', function() {
-    it('Calls the getOffset method with the correct argument', function() {
+    it('Calls the getOffset method where required with the correct argument', function() {
       var getOffsetSpy = sinon.spy(this.postMessages, '_getOffset');
 
       this.postMessages._updateMessage('jumpLink', 'content_1');
@@ -106,6 +106,9 @@ describe.only('PostMessages component', function() {
       this.postMessages._updateMessage('jumpLink', 'content_3');
       expect(getOffsetSpy.callCount).to.equal(3);
       assert(getOffsetSpy.calledWith('content_3'));
+
+      this.postMessages._updateMessage('masResize', 1200);
+      expect(getOffsetSpy.callCount).to.equal(3);
 
       getOffsetSpy.restore(); 
     }); 

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -1,4 +1,4 @@
-describe('PostMessages component', function() {
+describe.only('PostMessages component', function() {
   'use strict';
 
   beforeEach(function(done) {
@@ -47,7 +47,7 @@ describe('PostMessages component', function() {
     }); 
   });
 
-  describe.only('masResize method', function() {
+  describe('masResize method', function() {
     it('Calls the updateMessage method with the correct argument on body resize', function() {
       var clock = sinon.useFakeTimers();
       var updateMessageSpy = sinon.spy(this.postMessages, '_updateMessage');
@@ -56,7 +56,7 @@ describe('PostMessages component', function() {
       clock.tick(200);
 
       expect(updateMessageSpy.callCount).to.equal(1); 
-      expect(updateMessageSpy.calledWith('masResize', 1200)).to.be.true; 
+      assert(updateMessageSpy.calledWith('masResize', 1200)); 
 
       clock.restore(); 
       updateMessageSpy.restore(); 
@@ -64,22 +64,22 @@ describe('PostMessages component', function() {
   }); 
 
   describe('On clicking a jump link', function() {
-    it('Calls the updateMessage method with the correct argument', function() {
+    it('Calls the updateMessage method with the correct arguments', function() {
       var updateMessageSpy = sinon.spy(this.postMessages, '_updateMessage'); 
 
       this.postMessages._addEvents();
 
       this.component.find('#jump_link_1').trigger('click');
       expect(updateMessageSpy.callCount).to.equal(1);
-      assert(updateMessageSpy.calledWith('content_1'));
+      assert(updateMessageSpy.calledWith('jumpLink', 'content_1'));
 
       this.component.find('#jump_link_2').trigger('click');
       expect(updateMessageSpy.callCount).to.equal(2);
-      assert(updateMessageSpy.calledWith('content_2'));
+      assert(updateMessageSpy.calledWith('jumpLink', 'content_2'));
 
       this.component.find('#jump_link_3').trigger('click');
       expect(updateMessageSpy.callCount).to.equal(3);
-      assert(updateMessageSpy.calledWith('content_3'));
+      assert(updateMessageSpy.calledWith('jumpLink', 'content_3'));
 
       this.component.find('#external_link').trigger('click');
       expect(updateMessageSpy.callCount).to.equal(3);
@@ -95,15 +95,15 @@ describe('PostMessages component', function() {
     it('Calls the getOffset method with the correct argument', function() {
       var getOffsetSpy = sinon.spy(this.postMessages, '_getOffset');
 
-      this.postMessages._updateMessage('content_1');
+      this.postMessages._updateMessage('jumpLink', 'content_1');
       expect(getOffsetSpy.callCount).to.equal(1);
       assert(getOffsetSpy.calledWith('content_1'));
 
-      this.postMessages._updateMessage('content_2');
+      this.postMessages._updateMessage('jumpLink', 'content_2');
       expect(getOffsetSpy.callCount).to.equal(2);
       assert(getOffsetSpy.calledWith('content_2'));
 
-      this.postMessages._updateMessage('content_3');
+      this.postMessages._updateMessage('jumpLink', 'content_3');
       expect(getOffsetSpy.callCount).to.equal(3);
       assert(getOffsetSpy.calledWith('content_3'));
 
@@ -114,7 +114,7 @@ describe('PostMessages component', function() {
       var getOffsetStub = sinon.stub(this.postMessages, '_getOffset');
 
       getOffsetStub.returns(120); 
-      this.postMessages._updateMessage('content_1');
+      this.postMessages._updateMessage('jumpLink', 'content_1');
 
       expect(this.message.jumpLink.id).to.equal('content_1'); 
       expect(this.message.jumpLink.offset).to.equal(120); 


### PR DESCRIPTION
[TP-12564](https://maps.tpondemand.com/entity/12564-rad-scrolling-issue-on-firms-on)

This work extends the existing `PostMessages` Dough component to add a resize event. This is based on the script that is included in all syndicated tools and is fired when a change is detected in the body size of the document. It sends a message from the iFrame to the parent so that the iFrame height can be adjusted to fit the resized content. 