### PR TITLE
Post messages v5.45

### DIFF
--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -49,19 +49,28 @@ define(['DoughBaseComponent'],
    * Updates the message with required value
    */
   PostMessages.prototype._updateMessage = function(event, value) {
-    if (event === 'masResize') {
-      // Updates the message with height value for document
-      this.message = '';
-      this.message = 'MASRESIZE-' + value;
-    } else if (event === 'jumpLink') {
-      // Updates the message with vertical offset value for the supplied element
-      var offset = this._getOffset(value);
+    switch(event) {
+      case 'masResize': 
+        // Updates the message with height value for document
+        this.message = '';
+        this.message = 'MASRESIZE-' + value;
+        break;
+      case 'jumpLink': 
+        // Updates the message with vertical offset value for the supplied element
+        var offset = this._getOffset(value);
 
-      this.message = {}; 
-      this.message['jumpLink'] = {
-        id: value,
-        offset: offset
-      };
+        this.message = {}; 
+        this.message['jumpLink'] = {
+          id: value,
+          offset: offset
+        };
+        break; 
+      case 'scrollToTop': 
+        // Updates the message with vertical offset value of 0
+        this.message = {}; 
+        this.message['scrollToTop'] = {
+          offset: 0
+        };      
     }
 
     this._sendMessage(); 

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -10,7 +10,8 @@ define(['DoughBaseComponent'],
   var PostMessages, 
       message,
       defaultConfig = {
-        masresize: false
+        masresize: false, 
+        scrollToTop: false
       };
 
   PostMessages = function($el, config) {

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -70,7 +70,8 @@ define(['DoughBaseComponent'],
         this.message = {}; 
         this.message['scrollToTop'] = {
           offset: 0
-        };      
+        };
+        break; 
     }
 
     this._sendMessage(); 
@@ -89,7 +90,7 @@ define(['DoughBaseComponent'],
    * Sends the message
    */
   PostMessages.prototype._sendMessage = function() {
-    // console.log('message: ', this.message); 
+    console.log('message: ', this.message); 
     
     window.parent.postMessage(this.message, '*');
   }
@@ -97,7 +98,7 @@ define(['DoughBaseComponent'],
   /**
    * A method to update the message on changes to the document height
    */
-  PostMessages.prototype._masResize = function(masResize) {
+  PostMessages.prototype._masResize = function() {
     var _this = this, 
         currentHeight = 0, 
         timer,
@@ -120,22 +121,16 @@ define(['DoughBaseComponent'],
   /**
    * A method to update the message on document reloads
    */
-  PostMessages.prototype._scrollToTop = function(event) {
-    console.log('_scrollToTop!');
-
-    this._updateMessage(event);
+  PostMessages.prototype._scrollToTop = function() {
+    this._updateMessage('scrollToTop', null);
   }
 
   /**
   * @param {Promise} initialised
   */
   PostMessages.prototype.init = function(initialised) {
-    console.log('PostMessages init!'); 
-
     this._initialisedSuccess(initialised);
     this._addEvents();
-
-    console.log('scrollToTop: ', this.config.scrollToTop); 
 
     if (this.config.masresize) {
       this._masResize(); 

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -80,13 +80,13 @@ define(['DoughBaseComponent'],
    * Sends the message
    */
   PostMessages.prototype._sendMessage = function() {
-    console.log('message: ', this.message); 
+    // console.log('message: ', this.message); 
     
     window.parent.postMessage(this.message, '*');
   }
 
   /**
-   * A method to listen for changes to the document height
+   * A method to update the message on changes to the document height
    */
   PostMessages.prototype._masResize = function(masResize) {
     var _this = this, 
@@ -108,8 +108,13 @@ define(['DoughBaseComponent'],
     }, 200);
   }
 
-  PostMessages.prototype._scrollToTop = function() {
-    console.log('_scrollToTop!'); 
+  /**
+   * A method to update the message on document reloads
+   */
+  PostMessages.prototype._scrollToTop = function(event) {
+    console.log('_scrollToTop!');
+
+    this._updateMessage(event);
   }
 
   /**

--- a/assets/js/components/PostMessages.js
+++ b/assets/js/components/PostMessages.js
@@ -108,15 +108,27 @@ define(['DoughBaseComponent'],
     }, 200);
   }
 
+  PostMessages.prototype._scrollToTop = function() {
+    console.log('_scrollToTop!'); 
+  }
+
   /**
   * @param {Promise} initialised
   */
   PostMessages.prototype.init = function(initialised) {
+    console.log('PostMessages init!'); 
+
     this._initialisedSuccess(initialised);
     this._addEvents();
 
+    console.log('scrollToTop: ', this.config.scrollToTop); 
+
     if (this.config.masresize) {
       this._masResize(); 
+    }
+
+    if (this.config.scrollToTop) {
+      this._scrollToTop();
     }
   };
 

--- a/lib/dough/version.rb
+++ b/lib/dough/version.rb
@@ -1,3 +1,3 @@
 module Dough
-  VERSION = '5.44.0'.freeze
+  VERSION = '5.45.0'.freeze
 end

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -1,4 +1,4 @@
-describe('PostMessages component', function() {
+describe.only('PostMessages component', function() {
   'use strict';
 
   beforeEach(function(done) {
@@ -75,7 +75,7 @@ describe('PostMessages component', function() {
     }); 
   });
 
-  describe.only('scrollToTop method', function() {
+  describe('scrollToTop method', function() {
     it('Calls the updateMessage method with the correct arguments', function() {
       var updateMessageSpy = sinon.spy(this.postMessages, '_updateMessage');
 
@@ -135,6 +135,9 @@ describe('PostMessages component', function() {
       this.postMessages._updateMessage('masResize', 1200);
       expect(getOffsetSpy.callCount).to.equal(3);
 
+      this.postMessages._updateMessage('scrollToTop');
+      expect(getOffsetSpy.callCount).to.equal(3);
+
       getOffsetSpy.restore(); 
     }); 
 
@@ -144,7 +147,6 @@ describe('PostMessages component', function() {
 
       getOffsetStub.returns(120); 
       this.postMessages._updateMessage('jumpLink', 'content_1');
-
       expect(this.postMessages.message.jumpLink.id).to.equal('content_1'); 
       expect(this.postMessages.message.jumpLink.offset).to.equal(120); 
 
@@ -153,12 +155,17 @@ describe('PostMessages component', function() {
       // For masResize event
       this.postMessages._updateMessage('masResize', 1200);
       expect(this.postMessages.message).to.equal('MASRESIZE-1200'); 
+
+      // For scrollToTop event
+      this.postMessages._updateMessage('scrollToTop', null);
+      console.log(this.postMessages.message.scrollToTop.offset); 
+      expect(this.postMessages.message.scrollToTop.offset).to.equal(0);
     }); 
 
     it('Calls the sendMessage method', function() {
       var sendMessageSpy = sinon.spy(this.postMessages, '_sendMessage'); 
 
-      this.postMessages._updateMessage('content_1');
+      this.postMessages._updateMessage();
       expect(sendMessageSpy.calledOnce).to.be.true; 
 
       sendMessageSpy.restore(); 

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -158,7 +158,6 @@ describe.only('PostMessages component', function() {
 
       // For scrollToTop event
       this.postMessages._updateMessage('scrollToTop', null);
-      console.log(this.postMessages.message.scrollToTop.offset); 
       expect(this.postMessages.message.scrollToTop.offset).to.equal(0);
     }); 
 

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -22,7 +22,7 @@ describe('PostMessages component', function() {
     fixture.cleanup();
   });
 
-  describe.only('On initialising', function() {
+  describe('On initialising', function() {
     it('Calls the _addEvents method', function() {
       var addEventsSpy = sinon.spy(this.postMessages, '_addEvents'); 
 
@@ -60,7 +60,7 @@ describe('PostMessages component', function() {
   });
 
   describe('masResize method', function() {
-    it('Calls the updateMessage method with the correct argument on body resize', function() {
+    it('Calls the updateMessage method with the correct arguments', function() {
       var clock = sinon.useFakeTimers();
       var updateMessageSpy = sinon.spy(this.postMessages, '_updateMessage');
 
@@ -73,7 +73,20 @@ describe('PostMessages component', function() {
       clock.restore(); 
       updateMessageSpy.restore(); 
     }); 
-  }); 
+  });
+
+  describe.only('scrollToTop method', function() {
+    it('Calls the updateMessage method with the correct arguments', function() {
+      var updateMessageSpy = sinon.spy(this.postMessages, '_updateMessage');
+
+      this.postMessages._scrollToTop('scrollToTop');
+
+      expect(updateMessageSpy.callCount).to.equal(1); 
+      assert(updateMessageSpy.calledWith('scrollToTop')); 
+
+      updateMessageSpy.restore(); 
+    }); 
+  });
 
   describe('On clicking a jump link', function() {
     it('Calls the updateMessage method with the correct arguments', function() {

--- a/spec/js/tests/PostMessages_spec.js
+++ b/spec/js/tests/PostMessages_spec.js
@@ -22,7 +22,7 @@ describe('PostMessages component', function() {
     fixture.cleanup();
   });
 
-  describe('On initialising', function() {
+  describe.only('On initialising', function() {
     it('Calls the _addEvents method', function() {
       var addEventsSpy = sinon.spy(this.postMessages, '_addEvents'); 
 
@@ -43,6 +43,19 @@ describe('PostMessages component', function() {
       expect(masResizeSpy.calledOnce).to.be.true; 
 
       masResizeSpy.restore();
+    }); 
+
+    it('Calls the scrollToTop method if method config is true', function() {
+      var scrollToTopSpy = sinon.spy(this.postMessages, '_scrollToTop'); 
+
+      this.postMessages.init(); 
+      expect(scrollToTopSpy.called).to.be.false; 
+
+      this.postMessages.config.scrollToTop = true; 
+      this.postMessages.init(); 
+      expect(scrollToTopSpy.calledOnce).to.be.true; 
+
+      scrollToTopSpy.restore();
     }); 
   });
 


### PR DESCRIPTION
[TP-12641](https://maps.tpondemand.com/entity/12641-scroll-parent-page-to-top-when)

This work extends the `PostMessages` Dough component to send a message when the page reloads. This can be used on MoneyHelper to ensure the user is taken to the top of the tool when the content refreshes. 