### PR TITLE
Open email share link in new tab

### DIFF
--- a/app/views/dough/helpers/social_sharing_icons/_social_sharing_icons.html.erb
+++ b/app/views/dough/helpers/social_sharing_icons/_social_sharing_icons.html.erb
@@ -30,7 +30,8 @@
       </a>
     </li><li class="social-sharing__item social-sharing__item--email">
       <a class="social-sharing__item__icon"
-        href="mailto:?subject=<%= text %>&amp;body=<%= url %>"
+        href="mailto:?subject=<%= u(text) %>&amp;body=<%= url %>"
+        target="_blank"
         data-dough-shared-on="Email"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="social-sharing__icon--email svg-icon svg-icon--email" viewBox="18.375 10.556 31.249 18.889" aria-labelledby="social-sharing-email" focusable="false">


### PR DESCRIPTION
Also, escape the content of the `subject` attribute.

Fixes https://dev.azure.com.mcas.ms/moneyandpensionsservice/Digital%20Experience%20Platform%20-%20AEM/_boards/board/t/Team%201%20(Digital%20Support%20and%20Maintenance)/Stories/?workitem=3525